### PR TITLE
Add topology config import and scale restore

### DIFF
--- a/apps/web-ele/src/views/control/network-topology/components/CanvasRightPanel.vue
+++ b/apps/web-ele/src/views/control/network-topology/components/CanvasRightPanel.vue
@@ -16,6 +16,16 @@
     <div style="font-weight: bold; margin-bottom: 10px">
       已保存的画布
       <button @click="exportAllConfigs" style="float: right">全部导出</button>
+      <button @click="triggerImport" style="float: right; margin-right: 8px">
+        导入配置
+      </button>
+      <input
+        ref="fileInput"
+        type="file"
+        accept=".json"
+        style="display: none"
+        @change="onFileChange"
+      />
     </div>
     <template v-if="Object.keys(topoConfigs).length > 0">
       <div
@@ -72,6 +82,7 @@
 </template>
 
 <script setup lang="ts">
+import { ref } from 'vue';
 const props = defineProps([
   'topoConfigs',
   'connectMode',
@@ -83,10 +94,30 @@ const emits = defineEmits([
   'exportOneConfig',
   'removeConfig',
   'connectToExternalRoom',
+  'importConfigs',
 ]);
 const exportAllConfigs = () => emits('exportAllConfigs');
 const restoreConfigToCanvas = (cfg: any) => emits('restoreConfigToCanvas', cfg);
 const exportOneConfig = (name: string) => emits('exportOneConfig', name);
 const removeConfig = (name: string) => emits('removeConfig', name);
 const connectToExternalRoom = (name: string) => emits('connectToExternalRoom', name);
+
+const fileInput = ref<HTMLInputElement | null>(null);
+const triggerImport = () => fileInput.value?.click();
+function onFileChange(e: Event) {
+  const files = (e.target as HTMLInputElement).files;
+  if (!files || files.length === 0) return;
+  const file = files[0];
+  const reader = new FileReader();
+  reader.onload = () => {
+    try {
+      const data = JSON.parse(reader.result as string);
+      emits('importConfigs', data);
+    } catch (err) {
+      window.alert('配置文件解析失败');
+    }
+    if (fileInput.value) fileInput.value.value = '';
+  };
+  reader.readAsText(file);
+}
 </script>

--- a/apps/web-ele/src/views/control/network-topology/index.vue
+++ b/apps/web-ele/src/views/control/network-topology/index.vue
@@ -69,6 +69,9 @@ interface TopoConfig {
     _uuid: string;
     deviceId: string;
     position: { x: number; y: number };
+    scaleX?: number;
+    scaleY?: number;
+    parentCabinetId?: string | null;
   }[];
   edges: any[];
   saveTime?: number;
@@ -168,6 +171,9 @@ async function saveCurrentCanvasToConfigs() {
       deviceId: dev.deviceId,
       _uuid: dev._uuid,
       position: dev.position,
+      scaleX: dev.scaleX,
+      scaleY: dev.scaleY,
+      parentCabinetId: dev.parentCabinetId,
     })),
     edges: deepClone(edges.value),
     saveTime: Date.now(),
@@ -188,6 +194,9 @@ function restoreConfigToCanvas(config: TopoConfig) {
     const dev = deepClone(tmpl);
     dev._uuid = devCfg._uuid;
     dev.position = devCfg.position;
+    dev.scaleX = devCfg.scaleX ?? 1;
+    dev.scaleY = devCfg.scaleY ?? 1;
+    dev.parentCabinetId = devCfg.parentCabinetId ?? null;
     return dev;
   });
   edges.value = deepClone(config.edges);
@@ -218,6 +227,19 @@ function exportAllConfigs() {
   a.download = `all_topo_configs.json`;
   a.click();
   URL.revokeObjectURL(url);
+}
+
+function importConfigs(data: any) {
+  if (data && data.devices && data.edges) {
+    const name = window.prompt('导入的画布名称', `imported_${Date.now()}`) || '';
+    if (name) topoConfigs.value[name] = data as TopoConfig;
+  } else if (typeof data === 'object') {
+    Object.assign(topoConfigs.value, data);
+  } else {
+    window.alert('未知的配置格式');
+    return;
+  }
+  saveConfigsToStorage();
 }
 
 // API: 获取全部设备模板
@@ -710,6 +732,7 @@ onMounted(() => {
       @export-one-config="exportOneConfig"
       @remove-config="removeConfig"
       @connect-to-external-room="connectToExternalRoom"
+      @import-configs="importConfigs"
     />
   </div>
 </template>


### PR DESCRIPTION
## Summary
- preserve scale and parent cabinet info when saving/restoring topology configs
- add Import button and file input to CanvasRightPanel
- support importing configs from JSON

## Testing
- `pnpm lint` *(fails: vsh not found)*
- `pnpm test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cdc1224e48330af0cfc9c9f186fdd