### PR TITLE
Update device editor to use list API

### DIFF
--- a/apps/web-ele/src/router/routes/modules/industrialControl.ts
+++ b/apps/web-ele/src/router/routes/modules/industrialControl.ts
@@ -20,10 +20,9 @@ const controlRoutes: RouteRecordRaw[] = [
   // --- 设备编辑器 ---
   {
     name: 'DeviceEditor',
-    path: '/control/device-editor/:deviceId',
+    path: '/control/device-editor',
     component: () => import('#/views/control/device-editor/index.vue'),
     meta: { icon: 'lucide:pencil-ruler', title: '设备编辑', order: 2 },
-    props: true,
   },
 
   // --- 设备监控预览 ---


### PR DESCRIPTION
## Summary
- remove deviceId param from DeviceEditor route
- fetch device list when opening editor and let user choose
- load config and save using the selected device id

## Testing
- `pnpm lint` *(fails: stylelint errors)*

------
https://chatgpt.com/codex/tasks/task_e_687762a14028833086ad0db580d30a67