### PR TITLE
Allow cards display API data

### DIFF
--- a/apps/web-ele/src/components/DeviceNode.vue
+++ b/apps/web-ele/src/components/DeviceNode.vue
@@ -48,13 +48,4 @@ const { data } = defineProps<Props>();
 .icon.pc {
   /* 可用背景图或 emoji */
 }
-
-.icon.switch {
-}
-
-.icon.gateway {
-}
-
-.icon.plc {
-}
 </style>

--- a/apps/web-ele/src/components/business/DeviceEditor/PalettePanel.vue
+++ b/apps/web-ele/src/components/business/DeviceEditor/PalettePanel.vue
@@ -10,6 +10,10 @@ const props = defineProps<{
 }>();
 
 const PORT_ICON_URL = 'http://192.168.1.99:9000/qiuqiu/green.gif';
+const TABLE_ICON_URL =
+  'data:image/svg+xml,%3Csvg xmlns%3D"http://www.w3.org/2000/svg" width%3D"56" height%3D"56"%3E%3Crect x%3D"1" y%3D"1" width%3D"54" height%3D"54" fill%3D"%23fff" stroke%3D"%23ccc"/%3E%3Cline x1%3D"1" y1%3D"19" x2%3D"55" y2%3D"19" stroke%3D"%23ccc"/%3E%3Cline x1%3D"1" y1%3D"37" x2%3D"55" y2%3D"37" stroke%3D"%23ccc"/%3E%3Cline x1%3D"19" y1%3D"1" x2%3D"19" y2%3D"55" stroke%3D"%23ccc"/%3E%3Cline x1%3D"37" y1%3D"1" x2%3D"37" y2%3D"55" stroke%3D"%23ccc"/%3E%3C/svg%3E';
+const CARD_ICON_URL =
+  'data:image/svg+xml,%3Csvg xmlns%3D"http://www.w3.org/2000/svg" width%3D"56" height%3D"56"%3E%3Crect x%3D"1" y%3D"1" width%3D"54" height%3D"54" fill%3D"%23fff" stroke%3D"%23ccc"/%3E%3Ctext x%3D"28" y%3D"34" font-size%3D"20" text-anchor%3D"middle" fill%3D"%23ccc"%3ET%3C/text%3E%3C/svg%3E';
 const defaultFolderTree = [
   {
     id: 'root',
@@ -23,6 +27,20 @@ const defaultFolderTree = [
         url: PORT_ICON_URL,
         name: '端口',
         type: 'port',
+        isBuiltIn: true,
+      },
+      {
+        id: 'table-default',
+        url: TABLE_ICON_URL,
+        name: '表格',
+        type: 'table',
+        isBuiltIn: true,
+      },
+      {
+        id: 'card-default',
+        url: CARD_ICON_URL,
+        name: '卡片',
+        type: 'card',
         isBuiltIn: true,
       },
     ],

--- a/apps/web-ele/src/router/routes/modules/industrialControl.ts
+++ b/apps/web-ele/src/router/routes/modules/industrialControl.ts
@@ -20,10 +20,9 @@ const controlRoutes: RouteRecordRaw[] = [
   // --- 设备编辑器 ---
   {
     name: 'DeviceEditor',
-    path: '/control/device-editor/:deviceId',
+    path: '/control/device-editor',
     component: () => import('#/views/control/device-editor/index.vue'),
     meta: { icon: 'lucide:pencil-ruler', title: '设备编辑', order: 2 },
-    props: true,
   },
 
   // --- 设备监控预览 ---
@@ -34,12 +33,20 @@ const controlRoutes: RouteRecordRaw[] = [
     meta: { icon: 'lucide:monitor', title: '设备预览', order: 3 },
     props: true,
   },
+  // --- 简洁预览页面 ---
+  {
+    name: 'DeviceView',
+    path: '/control/device-view/:deviceId',
+    component: () => import('#/views/control/device-view/index.vue'),
+    meta: { icon: 'lucide:eye', title: '阅览', order: 4 },
+    props: true,
+  },
   // 机柜
   {
     name: 'Cabinet',
     path: '/control/cabinet',
     component: () => import('#/views/control/test/index.vue'),
-    meta: { icon: 'lucide:monitor', title: '机柜', order: 4 },
+    meta: { icon: 'lucide:monitor', title: '机柜', order: 5 },
   },
   // apps/web-ele/src/views/control/networkTopologyDiagram/components/TopologyGraph.vue
   {

--- a/apps/web-ele/src/views/control/big-screen/index.vue
+++ b/apps/web-ele/src/views/control/big-screen/index.vue
@@ -8,7 +8,6 @@ import TopHeader from './components/TopHeader.vue';
 </script>
 <template>
   <div class="dashboard">
-
     <TopHeader />
     <div class="grid-container">
       <dv-border-box8 :reverse="true" class="left">
@@ -48,7 +47,9 @@ import TopHeader from './components/TopHeader.vue';
   grid-template-areas:
     'left main right-top'
     'bottom-left main bottom-right';
+  /* stylelint-disable-next-line declaration-block-no-redundant-longhand-properties */
   grid-template-rows: 1fr 1fr;
+  /* stylelint-disable-next-line declaration-block-no-redundant-longhand-properties */
   grid-template-columns: 250px 1fr 300px;
   gap: 8px;
   padding: 8px;
@@ -79,10 +80,11 @@ import TopHeader from './components/TopHeader.vue';
   border-radius: 4px;
   box-shadow: 0 2px 6px rgb(0 0 0 / 40%);
 }
+
 .box {
-  height: 100%;
-  width: 100%;
-  padding: 12px;
   box-sizing: border-box;
+  width: 100%;
+  height: 100%;
+  padding: 12px;
 }
 </style>

--- a/apps/web-ele/src/views/control/device-editor/index.vue
+++ b/apps/web-ele/src/views/control/device-editor/index.vue
@@ -231,6 +231,59 @@ function startNewDevice() {
   rebuildAllApis();
 }
 
+function cloneView(type: ViewType): Config {
+  return deepClone(
+    type === 'front'
+      ? frontConfig.value
+      : type === 'back'
+        ? backConfig.value
+        : detailConfig.value,
+  );
+}
+
+function copyView(from: ViewType, to: ViewType) {
+  const data = cloneView(from);
+  if (to === 'front') frontConfig.value = data;
+  else if (to === 'back') backConfig.value = data;
+  else detailConfig.value = data;
+  pushHistory();
+  rebuildAllApis();
+}
+
+function moveView(from: ViewType, to: ViewType) {
+  copyView(from, to);
+  const empty = createDefaultConfig();
+  if (from === 'front') frontConfig.value = empty;
+  else if (from === 'back') backConfig.value = empty;
+  else detailConfig.value = empty;
+  pushHistory();
+  rebuildAllApis();
+}
+
+function handleCopyView() {
+  const target = prompt(
+    '选择要复制到的页面(front/back/detail)',
+    viewType.value === 'front' ? 'back' : 'front',
+  );
+  if (!target) return;
+  const t = target.trim() as ViewType;
+  if (t === viewType.value || !['front', 'back', 'detail'].includes(t)) return;
+  copyView(viewType.value, t);
+  alert('复制成功！');
+}
+
+function handleMoveView() {
+  const target = prompt(
+    '选择要迁移到的页面(front/back/detail)',
+    viewType.value === 'front' ? 'back' : 'front',
+  );
+  if (!target) return;
+  const t = target.trim() as ViewType;
+  if (t === viewType.value || !['front', 'back', 'detail'].includes(t)) return;
+  moveView(viewType.value, t);
+  alert('迁移成功！');
+}
+
 /* -------------------------------------------------------------------------- */
 /* 历史撤销栈                                                                  */
 /* -------------------------------------------------------------------------- */
@@ -453,6 +506,18 @@ async function handlePreview() {
         <option value="back">背面</option>
         <option value="detail">详情</option>
       </select>
+      <button
+        @click="handleCopyView"
+        class="btn-primary border-[#3ae0ff] hover:bg-[#23242a]"
+      >
+        复制
+      </button>
+      <button
+        @click="handleMoveView"
+        class="btn-primary border-[#ff6384] hover:bg-[#23242a]"
+      >
+        迁移
+      </button>
       <button
         @click="startNewDevice"
         class="btn-primary border-[#38dbb8] bg-[#2ba672] hover:bg-[#225a45]"

--- a/apps/web-ele/src/views/control/device-editor/index.vue
+++ b/apps/web-ele/src/views/control/device-editor/index.vue
@@ -324,18 +324,17 @@ async function loadConfig(id: string) {
     const json = await resp.json();
 
     if (json.code === 200 && json.data) {
-      let front: Partial<Config> = {};
-      let back: Partial<Config> = {};
-      let detail: Partial<Config> = {};
-      try {
-        front = JSON.parse(json.data.deviceJson || '{}');
-      } catch {}
-      try {
-        back = JSON.parse(json.data.deviceBack || '{}');
-      } catch {}
-      try {
-        detail = JSON.parse(json.data.deviceDetails || '{}');
-      } catch {}
+      const parseCfg = (val: any): Partial<Config> => {
+        try {
+          const obj = JSON.parse(val ?? '{}');
+          return obj && typeof obj === 'object' ? obj : {};
+        } catch {
+          return {};
+        }
+      };
+      const front = parseCfg(json.data.deviceJson);
+      const back = parseCfg(json.data.deviceBack);
+      const detail = parseCfg(json.data.deviceDetails);
 
       for (const obj of [front, back, detail]) {
         obj.layers = Array.isArray(obj.layers) ? obj.layers : [];

--- a/apps/web-ele/src/views/control/device-preview/index.vue
+++ b/apps/web-ele/src/views/control/device-preview/index.vue
@@ -1,13 +1,13 @@
 <script setup lang="ts">
-import { onMounted, ref, computed } from 'vue';
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
 import { useRoute } from 'vue-router';
 
-// 直接复用渲染组件
-import DevicePreviewRender from './DevicePreviewRender.vue';
-// 顶部 logo
-import topHeader from './assets/topHeader.png';
 // 风扇动图
 import fanGif from './assets/fan.gif';
+// 顶部 logo
+import topHeader from './assets/topHeader.png';
+// 直接复用渲染组件
+import DevicePreviewRender from './DevicePreviewRender.vue';
 
 /* ───── 路由参数 ───── */
 const route = useRoute();
@@ -19,8 +19,23 @@ const loading = ref(true);
 const error = ref('');
 const selectedLayerId = ref<null | string>(null); // 预览不可编辑，占位即可
 
+const previewRef = ref<HTMLElement | null>(null);
+const scale = ref(1);
+function updateScale() {
+  if (!previewRef.value || !config.value) return;
+  const { clientWidth, clientHeight } = previewRef.value;
+  const w = config.value.width || 1920;
+  const h = config.value.height || 1080;
+  // 不再限制最大倍率，旧配置尺寸过小时也能放大
+  scale.value = Math.min(clientWidth / w, clientHeight / h);
+}
+onMounted(() => {
+  window.addEventListener('resize', updateScale);
+});
+onUnmounted(() => window.removeEventListener('resize', updateScale));
+
 /* ───── 视图切换 ───── */
-const viewMode = ref<'device' | 'detail'>('device');
+const viewMode = ref<'detail' | 'device'>('device');
 const toggleView = () => {
   viewMode.value = viewMode.value === 'device' ? 'detail' : 'device';
 };
@@ -76,8 +91,8 @@ async function loadConfig() {
       /* 设定默认宽高，避免 0 / undefined */
       config.value = {
         deviceId: deviceId.value,
-        width: parsed.width || 900,
-        height: parsed.height || 600,
+        width: parsed.width || 1920,
+        height: parsed.height || 1080,
         ...parsed,
       };
     } else {
@@ -101,34 +116,43 @@ async function loadDeviceInfo() {
     return resp.json();
   }
   try {
-    const [port, cpu, fan, mac, model, name, temp, loc, run] = await Promise.all([
-      post('/getPortStateInfo'),
-      post('/getCpuInfo'),
-      post('/getFanInfo'),
-      post('/getMacAddress'),
-      post('/getModel'),
-      post('/getDeviceName'),
-      post('/getTemperature'),
-      post('/getPhysicalLocation'),
-      post('/getSysRunTime'),
-    ]);
+    const [port, cpu, fan, mac, model, name, temp, loc, run] =
+      await Promise.all([
+        post('/getPortStateInfo'),
+        post('/getCpuInfo'),
+        post('/getFanInfo'),
+        post('/getMacAddress'),
+        post('/getModel'),
+        post('/getDeviceName'),
+        post('/getTemperature'),
+        post('/getPhysicalLocation'),
+        post('/getSysRunTime'),
+      ]);
 
     if (port?.code === 200) tableRows.value = port.data || [];
-    if (cpu?.code === 200) deviceInfo.value.cpu = Number(cpu.data?.cpuValue) || 0;
+    if (cpu?.code === 200)
+      deviceInfo.value.cpu = Number(cpu.data?.cpuValue) || 0;
     if (fan?.code === 200) deviceInfo.value.fan = fan.data?.[0]?.speed ?? '';
-    if (mac?.code === 200) deviceInfo.value.macAddress = mac.data?.macValue || '';
-    if (model?.code === 200) deviceInfo.value.model = model.data?.modelValue || '';
+    if (mac?.code === 200)
+      deviceInfo.value.macAddress = mac.data?.macValue || '';
+    if (model?.code === 200)
+      deviceInfo.value.model = model.data?.modelValue || '';
     if (name?.code === 200) deviceInfo.value.name = name.data?.nameValue || '';
-    if (temp?.code === 200) deviceInfo.value.temperature = temp.data?.temperatureValue || '';
-    if (loc?.code === 200) deviceInfo.value.location = loc.data?.locationValue || '';
-    if (run?.code === 200) deviceInfo.value.sysRunTime = run.data?.runTimeValue || '';
-  } catch (e) {
-    console.error('loadDeviceInfo error', e);
+    if (temp?.code === 200)
+      deviceInfo.value.temperature = temp.data?.temperatureValue || '';
+    if (loc?.code === 200)
+      deviceInfo.value.location = loc.data?.locationValue || '';
+    if (run?.code === 200)
+      deviceInfo.value.sysRunTime = run.data?.runTimeValue || '';
+  } catch (error_) {
+    console.error('loadDeviceInfo error', error_);
   }
 }
 
 onMounted(loadConfig);
 onMounted(loadDeviceInfo);
+watch(config, updateScale);
+onMounted(updateScale);
 </script>
 
 <template>
@@ -159,8 +183,16 @@ onMounted(loadDeviceInfo);
         <!-- 设备视图 -->
         <!-- 设备视图 -->
         <div v-if="viewMode === 'device'">
-          <div class="switch-preview flex justify-center">
-            <div class="device-render">
+          <div ref="previewRef" class="switch-preview flex h-full items-center justify-center">
+            <div
+              class="device-render"
+              :style="{
+                transform: `scale(${scale})`,
+                transformOrigin: 'top left',
+                width: `${config.width}px`,
+                height: `${config.height}px`,
+              }"
+            >
               <DevicePreviewRender :config="config" />
             </div>
           </div>
@@ -168,43 +200,61 @@ onMounted(loadDeviceInfo);
 
         <!-- 详细信息视图 -->
         <div v-else>
-          <div class="detail-panel text-white p-6 flex flex-col lg:flex-row gap-12">
-            <h2 class="text-xl mb-2 font-semibold">设备详细信息</h2>
+          <div
+            class="detail-panel flex flex-col gap-12 p-6 text-white lg:flex-row"
+          >
+            <h2 class="mb-2 text-xl font-semibold">设备详细信息</h2>
             <ul class="space-y-1 text-sm leading-6">
               <li>产品型号：{{ deviceInfo.model || '-' }}</li>
               <li>设备名称：{{ deviceInfo.name || '-' }}</li>
               <li>运行时间：{{ deviceInfo.sysRunTime || '-' }}</li>
               <li>MAC 地址：{{ deviceInfo.macAddress || '-' }}</li>
-              <li v-if="deviceInfo.location">位置：{{ deviceInfo.location }}</li>
+              <li v-if="deviceInfo.location">
+                位置：{{ deviceInfo.location }}
+              </li>
             </ul>
 
-            <div class="metrics flex flex-wrap gap-12 justify-center lg:justify-start items-center">
+            <div
+              class="metrics flex flex-wrap items-center justify-center gap-12 lg:justify-start"
+            >
               <!-- CPU -->
               <div class="metric text-center">
                 <svg viewBox="0 0 36 36" class="circular-chart">
-                  <path class="circle-bg"
-                        d="M18 2.0845
+                  <path
+                    class="circle-bg"
+                    d="M18 2.0845
                        a 15.9155 15.9155 0 0 1 0 31.831
-                       a 15.9155 15.9155 0 0 1 0 -31.831"/>
-                  <path class="circle" :stroke-dasharray="`${deviceInfo.cpu},100`"
-                        d="M18 2.0845
+                       a 15.9155 15.9155 0 0 1 0 -31.831"
+                  />
+                  <path
+                    class="circle"
+                    :stroke-dasharray="`${deviceInfo.cpu},100`"
+                    d="M18 2.0845
                        a 15.9155 15.9155 0 0 1 0 31.831
-                       a 15.9155 15.9155 0 0 1 0 -31.831"/>
-                  <text x="18" y="20.35" class="percentage">{{ deviceInfo.cpu }}%</text>
+                       a 15.9155 15.9155 0 0 1 0 -31.831"
+                  />
+                  <text x="18" y="20.35" class="percentage">
+                    {{ deviceInfo.cpu }}%
+                  </text>
                 </svg>
                 <div class="metric-title mt-2">CPU 占用率</div>
               </div>
               <!-- Memory -->
               <div class="metric text-center">
                 <svg viewBox="0 0 36 36" class="circular-chart">
-                  <path class="circle-bg"
-                        d="M18 2.0845
+                  <path
+                    class="circle-bg"
+                    d="M18 2.0845
                        a 15.9155 15.9155 15.9155 0 0 1 0 31.831
-                       a 15.9155 15.9155 15.9155 0 0 1 0 -31.831"/>
-                  <path class="circle" :stroke-dasharray="'12,100'"
-                        d="M18 2.0845
+                       a 15.9155 15.9155 15.9155 0 0 1 0 -31.831"
+                  />
+                  <path
+                    class="circle"
+                    stroke-dasharray="12,100"
+                    d="M18 2.0845
                        a 15.9155 15.9155 15.9155 0 0 1 0 31.831
-                       a 15.9155 15.9155 15.9155 0 0 1 0 -31.831"/>
+                       a 15.9155 15.9155 15.9155 0 0 1 0 -31.831"
+                  />
                   <text x="18" y="20.35" class="percentage">12%</text>
                 </svg>
                 <div class="metric-title mt-2">内存占用率</div>
@@ -212,32 +262,38 @@ onMounted(loadDeviceInfo);
               <!-- 温度 -->
               <div class="metric text-center">
                 <svg viewBox="0 0 36 36" class="circular-chart">
-                  <path class="circle-bg"
-                        d="M18 2.0845
+                  <path
+                    class="circle-bg"
+                    d="M18 2.0845
                        a 15.9155 15.9155 15.9155 0 0 1 0 31.831
-                       a 15.9155 15.9155 15.9155 0 0 1 0 -31.831"/>
-                  <text x="18" y="20.35" class="percentage">{{ deviceInfo.temperature }}</text>
+                       a 15.9155 15.9155 15.9155 0 0 1 0 -31.831"
+                  />
+                  <text x="18" y="20.35" class="percentage">
+                    {{ deviceInfo.temperature }}
+                  </text>
                 </svg>
                 <div class="metric-title mt-2">温度</div>
               </div>
               <!-- Fan -->
               <div class="metric text-center">
-                <img :src="fanGif" alt="Fan" class="w-16 h-16 mx-auto" />
-                <div class="metric-title mt-2">风扇状态：{{ deviceInfo.fan }}</div>
+                <img :src="fanGif" alt="Fan" class="mx-auto h-16 w-16" />
+                <div class="metric-title mt-2">
+                  风扇状态：{{ deviceInfo.fan }}
+                </div>
               </div>
             </div>
           </div>
         </div>
 
         <!-- 端口信息表 (始终显示) -->
-        <div class="table-wrapper mt-6 overflow-auto max-h-72">
+        <div class="table-wrapper mt-6 max-h-72 overflow-auto">
           <table class="w-full text-sm">
             <thead>
               <tr class="bg-[#006b9e] text-white">
-                <th class="py-2 px-3 text-left w-16">序号</th>
-                <th class="py-2 px-3 text-left">端口名称</th>
-                <th class="py-2 px-3 text-left">IP 地址</th>
-                <th class="py-2 px-3 text-left">状态</th>
+                <th class="w-16 px-3 py-2 text-left">序号</th>
+                <th class="px-3 py-2 text-left">端口名称</th>
+                <th class="px-3 py-2 text-left">IP 地址</th>
+                <th class="px-3 py-2 text-left">状态</th>
               </tr>
             </thead>
             <tbody>
@@ -247,17 +303,23 @@ onMounted(loadDeviceInfo);
                 :class="idx % 2 === 0 ? 'bg-[#00294d]' : 'bg-[#063158]'"
                 class="text-white"
               >
-                <td class="py-2 px-3">{{ idx + 1 }}</td>
-                <td class="py-2 px-3">{{ row.portName }}</td>
-                <td class="py-2 px-3">{{ row.portIp ? row.portIp.join(', ') : '-' }}</td>
-                <td class="py-2 px-3">{{ row.portStatus === 1 ? '连接' : '未连接' }}</td>
+                <td class="px-3 py-2">{{ idx + 1 }}</td>
+                <td class="px-3 py-2">{{ row.portName }}</td>
+                <td class="px-3 py-2">
+                  {{ row.portIp ? row.portIp.join(', ') : '-' }}
+                </td>
+                <td class="px-3 py-2">
+                  {{ row.portStatus === 1 ? '连接' : '未连接' }}
+                </td>
               </tr>
             </tbody>
           </table>
         </div>
       </div>
-    </div> <!-- .device-preview-page -->
-  </div>   <!-- .device-preview-container -->
+    </div>
+    <!-- .device-preview-page -->
+  </div>
+  <!-- .device-preview-container -->
 </template>
 
 <style scoped>
@@ -266,53 +328,57 @@ onMounted(loadDeviceInfo);
   flex-direction: column;
   height: 100vh;
 }
+
 .top-header {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center; /* center logo horizontally */
   width: 100%;
   height: 100px;
-  display: flex;
-  justify-content: center;   /* center logo horizontally */
-  align-items: center;
   background-color: #161a21;
 }
-.top-header img {
-  max-height: 120px;          /* shrink oversized logo */
 
+.top-header img {
+  max-height: 120px; /* shrink oversized logo */
   object-fit: contain;
 }
+
 .device-preview-page {
   flex: 1;
   min-height: 0;
 }
+
 .switch-preview {
-  width: 100%;
   display: flex;
   justify-content: center;
-  margin-top: 16px;
-}
-.device-render {
-  transform: scale(1.4);       /* proportional enlarge */
-  transform-origin: top center;
+  align-items: center;
+  width: 100%;
+  height: 100%;
 }
 
-.top-header {
-  position: relative;
+.device-render {
+  /* scale handled dynamically via style binding */
 }
+
 .toggle-btn {
   position: absolute;
-  right: 24px;
   top: 50%;
-  transform: translateY(-50%);
-  border: 1px solid #3ae0ff;
-  background: #2a69d7;
+  right: 24px;
   padding: 4px 14px;
   font-size: 14px;
   color: #fff;
-  border-radius: 4px;
   cursor: pointer;
+  background: #2a69d7;
+  border: 1px solid #3ae0ff;
+  border-radius: 4px;
+  transform: translateY(-50%);
 }
+
 .toggle-btn:hover {
   background: #154c8a;
 }
+
 .detail-panel {
   max-width: 960px;
   margin: 0 auto;
@@ -322,11 +388,13 @@ onMounted(loadDeviceInfo);
   width: 80px;
   height: 80px;
 }
+
 .circle-bg {
   fill: none;
   stroke: #29303d;
   stroke-width: 3;
 }
+
 .circle {
   fill: none;
   stroke: #3ae0ff;
@@ -335,11 +403,12 @@ onMounted(loadDeviceInfo);
   transform: rotate(-90deg);
   transform-origin: center;
 }
+
 .percentage {
-  fill: #ffffff;
   font-size: 10px;
-  text-anchor: middle;
   dominant-baseline: central;
+  text-anchor: middle;
+  fill: #fff;
 }
 
 .table-wrapper {

--- a/apps/web-ele/src/views/control/device-view/index.vue
+++ b/apps/web-ele/src/views/control/device-view/index.vue
@@ -1,0 +1,102 @@
+<script setup lang="ts">
+import { onMounted, onUnmounted, ref, watch } from 'vue';
+import { useRoute } from 'vue-router';
+import DevicePreviewRender from '#/views/control/device-preview/DevicePreviewRender.vue';
+
+const route = useRoute();
+const deviceId = ref((route.params.deviceId as string) || '');
+const config = ref<any>(null);
+const loading = ref(true);
+const error = ref('');
+const viewRef = ref<HTMLElement | null>(null);
+const scale = ref(1);
+function updateScale() {
+  if (!viewRef.value || !config.value) return;
+  const { clientWidth, clientHeight } = viewRef.value;
+  const w = config.value.width || 1920;
+  const h = config.value.height || 1080;
+  // 不限制放大倍率，小尺寸配置也能全屏展示
+  scale.value = Math.min(clientWidth / w, clientHeight / h);
+}
+
+async function loadConfig() {
+  loading.value = true;
+  error.value = '';
+  try {
+    const resp = await fetch(`/api/jx-device/Device/${deviceId.value}`);
+    const json = await resp.json();
+    if (json.code === 200 && json.data?.deviceJson) {
+      let parsed: any = {};
+      try {
+        parsed = JSON.parse(json.data.deviceJson);
+      } catch {
+        console.warn('deviceJson parse failed');
+      }
+      parsed.layers = Array.isArray(parsed.layers) ? parsed.layers : [];
+      parsed.materialsTree = Array.isArray(parsed.materialsTree)
+        ? parsed.materialsTree
+        : [];
+      config.value = { deviceId: deviceId.value, width: 1920, height: 1080, ...parsed };
+    } else {
+      error.value = json.msg || '未找到设备配置';
+    }
+  } catch (err) {
+    error.value = '加载失败';
+    console.error(err);
+  }
+  loading.value = false;
+}
+
+onMounted(loadConfig);
+watch(
+  () => route.params.deviceId,
+  (id) => {
+    deviceId.value = (id as string) || '';
+    loadConfig();
+  },
+);
+watch(config, updateScale);
+onMounted(() => {
+  window.addEventListener('resize', updateScale);
+  updateScale();
+});
+onUnmounted(() => window.removeEventListener('resize', updateScale));
+</script>
+
+<template>
+  <div class="device-view-page">
+    <div v-if="loading" class="status">加载中…</div>
+    <div v-else-if="error" class="status text-red-400">{{ error }}</div>
+    <div
+      v-else
+      ref="viewRef"
+      class="flex h-full items-center justify-center bg-[#181a20]"
+    >
+      <div
+        :style="{
+          transform: `scale(${scale})`,
+          transformOrigin: 'top left',
+          width: `${config.width}px`,
+          height: `${config.height}px`,
+        }"
+      >
+        <DevicePreviewRender :config="config" with-redis-state />
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.device-view-page {
+  position: fixed;
+  inset: 0;
+}
+.status {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: #ccc;
+  background: #181a20;
+}
+</style>

--- a/apps/web-ele/src/views/control/network-topology/CabinetView.vue
+++ b/apps/web-ele/src/views/control/network-topology/CabinetView.vue
@@ -1,21 +1,44 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+
+/* props */
+const props = defineProps<{
+  cabinet: any; // 实例
+  hoverInfo: null | { cabinetId: string; uHeight: number; uStart: number };
+  templatesMap: Record<string, any>;
+}>();
+const tpl = computed(
+  () =>
+    props.templatesMap[props.cabinet.deviceId] || {
+      width: 480,
+      height: 900,
+      totalU: 42,
+    },
+);
+const slotH = computed(() => tpl.value.height / tpl.value.totalU);
+const hoverVisible = computed(
+  () => props.hoverInfo && props.hoverInfo.cabinetId === props.cabinet._uuid,
+);
+</script>
+
 <template>
   <div
     class="cabinet"
     :style="{
-      left: cabinet.position.x + 'px',
-      top: cabinet.position.y + 'px',
-      width: tpl.width + 'px',
-      height: tpl.height + 'px'
+      left: `${cabinet.position.x}px`,
+      top: `${cabinet.position.y}px`,
+      width: `${tpl.width}px`,
+      height: `${tpl.height}px`,
     }"
-    @mousedown="$emit('start-drag-cabinet',$event)"
+    @mousedown="$emit('start-drag-cabinet', $event)"
   >
     <!-- U 槽：U42 在最上方 → U1 在最下 -->
     <div
       v-for="u in tpl.totalU"
       :key="u"
       class="u-slot"
-      :style="{height:slotH+'px'}"
-      :class="{hover:hoverVisible && hoverInfo.uStart===u}"
+      :style="{ height: `${slotH}px` }"
+      :class="{ hover: hoverVisible && hoverInfo.uStart === u }"
     >
       <span class="u-label"></span>
       <!-- 占位高亮（内部已吸附设备）-->
@@ -25,8 +48,8 @@
         v-if="u >= inner.uStart && u < inner.uStart + inner.uHeight"
         class="inner-fill"
         :style="{
-          height: inner.uHeight * slotH - 2 + 'px',
-          lineHeight: inner.uHeight * slotH - 2 + 'px'
+          height: `${inner.uHeight * slotH - 2}px`,
+          lineHeight: `${inner.uHeight * slotH - 2}px`,
         }"
       ></div>
     </div>
@@ -36,7 +59,7 @@
       <div
         v-if="hoverVisible"
         class="u-indicator"
-        :style="{fontSize: slotH*1.2 + 'px'}"
+        :style="{ fontSize: `${slotH * 1.2}px` }"
       >
         {{ hoverInfo.uHeight }}U
       </div>
@@ -44,42 +67,71 @@
   </div>
 </template>
 
-<script setup lang="ts">
-import { computed } from 'vue'
-
-/* props */
-const props = defineProps<{
-  cabinet     : any            // 实例
-  templatesMap: Record<string,any>
-  hoverInfo   : null|{cabinetId:string;uStart:number;uHeight:number}
-}>()
-const tpl     = computed(()=> props.templatesMap[props.cabinet.deviceId] || {width:480,height:900,totalU:42})
-const slotH   = computed(()=> tpl.value.height / tpl.value.totalU )
-const hoverVisible = computed(()=> props.hoverInfo && props.hoverInfo.cabinetId===props.cabinet._uuid)
-</script>
-
 <style scoped>
-.cabinet{
-  position:absolute;user-select:none;cursor:move;
-  border:2px solid #00e5ff;background:#1c2027;box-shadow:0 0 8px #00e5ff33;
+.cabinet {
+  position: absolute;
+  cursor: move;
+  user-select: none;
+  background: #1c2027;
+  border: 2px solid #00e5ff;
+  box-shadow: 0 0 8px #00e5ff33;
 }
-.u-slot{
-  position:relative;border-top:1px dashed #2f333b;width:100%;box-sizing:border-box;
+
+.u-slot {
+  position: relative;
+  box-sizing: border-box;
+  width: 100%;
+  border-top: 1px dashed #2f333b;
 }
-.u-slot.hover{background:#0ff3/12}
-.u-label{position:absolute;left:4px;top:0;font-size:10px;color:#444}
-.inner-fill{
-  position:absolute;left:1px;top:1px;right:1px;
-  background:#0f669933;border:1px solid #3cf5ff33;
+
+.u-slot.hover {
+  background: rgb(0 255 255 / 12%);
 }
-.u-indicator{
-  position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);
-  padding:4px 16px;background:#0bcfff22;border:1px solid #38d9ff99;
-  color:#38d9ff;font-weight:700;border-radius:6px;opacity:0;
-  animation:fadein 0.4s ease 1s forwards;
-  pointer-events:none;
+
+.u-label {
+  position: absolute;
+  top: 0;
+  left: 4px;
+  font-size: 10px;
+  color: #444;
 }
-@keyframes fadein{to{opacity:1}}
-.fade-leave-active{transition:opacity .25s}
-.fade-leave-to{opacity:0}
+
+.inner-fill {
+  position: absolute;
+  top: 1px;
+  right: 1px;
+  left: 1px;
+  background: #0f669933;
+  border: 1px solid #3cf5ff33;
+}
+
+.u-indicator {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  padding: 4px 16px;
+  font-weight: 700;
+  color: #38d9ff;
+  pointer-events: none;
+  background: #0bcfff22;
+  border: 1px solid #38d9ff99;
+  border-radius: 6px;
+  opacity: 0;
+  transform: translate(-50%, -50%);
+  animation: fadein 0.4s ease 1s forwards;
+}
+
+@keyframes fadein {
+  to {
+    opacity: 1;
+  }
+}
+
+.fade-leave-active {
+  transition: opacity 0.25s;
+}
+
+.fade-leave-to {
+  opacity: 0;
+}
 </style>

--- a/apps/web-ele/src/views/control/network-topology/components/TopoToolbar.vue
+++ b/apps/web-ele/src/views/control/network-topology/components/TopoToolbar.vue
@@ -13,10 +13,35 @@
 
     <!-- 添加普通设备 -->
     <button @click="emit('add-device')">添加设备到画布</button>
-
+    
     <!-- ★ 新增：添加机柜按钮 -->
     <button @click="emit('add-cabinet')" style="background:#444;color:#fff">
       添加机柜
+    </button>
+
+    <!-- 画布大小设置 -->
+    <label style="margin-left:8px">W:</label>
+    <input
+      type="number"
+      :value="canvasWidth"
+      style="width:80px"
+      @input="
+        emit('update:canvas-width', ($event.target as HTMLInputElement).valueAsNumber)
+      "
+    />
+    <label>H:</label>
+    <input
+      type="number"
+      :value="canvasHeight"
+      style="width:80px"
+      @input="
+        emit('update:canvas-height', ($event.target as HTMLInputElement).valueAsNumber)
+      "
+    />
+
+    <!-- 删除选中设备 -->
+    <button @click="emit('remove-selected-device')" style="color:#f44">
+      删除设备
     </button>
 
     <!-- 保存画布相关 -->
@@ -59,13 +84,17 @@
 </template>
 
 <script setup lang="ts">
+import { toRefs } from 'vue';
 /* ---------- props / emits ---------- */
 const props = defineProps<{
   selectedDeviceId: string;
   allDeviceOptions: any[];
   newConfigName: string;
   connectMode: string;
+  canvasWidth: number;
+  canvasHeight: number;
 }>();
+const { canvasWidth, canvasHeight } = toRefs(props);
 
 const emit = defineEmits([
   'update:selected-device-id',
@@ -74,6 +103,9 @@ const emit = defineEmits([
   'add-cabinet', // ★ 新增
   'save-current-canvas-to-configs',
   'set-connect-mode',
+  'update:canvas-width',
+  'update:canvas-height',
+  'remove-selected-device',
 ]);
 
 /* ---------- methods ---------- */

--- a/apps/web-ele/src/views/control/network-topology/index.vue
+++ b/apps/web-ele/src/views/control/network-topology/index.vue
@@ -260,8 +260,8 @@ async function fetchDevices() {
       } catch {}
       return {
         deviceId: String(row.deviceId),
-        width: cfg.width ?? 900,
-        height: cfg.height ?? 600,
+        width: cfg.width ?? 1920,
+        height: cfg.height ?? 1080,
         layers: Array.isArray(cfg.layers) ? cfg.layers : [],
         materialsTree: Array.isArray(cfg.materialsTree)
           ? cfg.materialsTree

--- a/apps/web-ele/src/views/control/network-topology/index.vue
+++ b/apps/web-ele/src/views/control/network-topology/index.vue
@@ -183,6 +183,10 @@ async function saveCurrentCanvasToConfigs() {
   saveConfigsToStorage();
   newConfigName.value = '';
   alert(`画布【${name}】已保存`);
+
+  // 清空当前画布方便继续新建
+  devicesOnCanvas.value = [];
+  edges.value = [];
 }
 
 function restoreConfigToCanvas(config: TopoConfig) {

--- a/apps/web-ele/src/views/control/network-topology/index.vue
+++ b/apps/web-ele/src/views/control/network-topology/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { nextTick, onMounted, ref } from 'vue';
+import { nextTick, onMounted, onUnmounted, ref } from 'vue';
 
 import html2canvas from 'html2canvas';
 

--- a/apps/web-ele/src/views/control/network-topology/index.vue
+++ b/apps/web-ele/src/views/control/network-topology/index.vue
@@ -314,8 +314,17 @@ function addDevice() {
     x: Math.floor(60 + Math.random() * 500),
     y: Math.floor(60 + Math.random() * 300),
   };
-  newDev.scaleX = 1;
-  newDev.scaleY = 1;
+  if (tmpl.deviceId === 'POWER-CABINET') {
+    const w =
+      Number(window.prompt('配电柜宽度(px)', String(tmpl.width))) || tmpl.width;
+    const h =
+      Number(window.prompt('配电柜高度(px)', String(tmpl.height))) || tmpl.height;
+    newDev.scaleX = w / tmpl.width;
+    newDev.scaleY = h / tmpl.height;
+  } else {
+    newDev.scaleX = 1;
+    newDev.scaleY = 1;
+  }
   newDev.parentCabinetId = null;
   devicesOnCanvas.value.push(newDev);
 }
@@ -335,8 +344,8 @@ function onDragMove(e: MouseEvent) {
   if (!dragging.value || !dragDevice.value) return;
   let nx = e.clientX - dragStart.value.x;
   let ny = e.clientY - dragStart.value.y;
-  nx = Math.max(0, Math.min(nx, 1100));
-  ny = Math.max(0, Math.min(ny, 700));
+  nx = Math.max(0, Math.min(nx, 1820));
+  ny = Math.max(0, Math.min(ny, 980));
   // 如果拖动的是机柜，同步移动其子设备
   if (
     dragDevice.value &&
@@ -504,8 +513,8 @@ function getEdgePositions(edge: any) {
     const roomList = Object.keys(topoConfigs.value);
     const idx = roomList.indexOf((edge.target as any).externalRoom);
     const canvasRect = canvasDomRef.value?.getBoundingClientRect?.();
-    const canvasWidth = canvasRect?.width || 1200;
-    const canvasHeight = canvasRect?.height || 800;
+    const canvasWidth = canvasRect?.width || 1920;
+    const canvasHeight = canvasRect?.height || 1080;
     const roomCount = roomList.length;
     const gapY = Math.max(60, (canvasHeight - 240) / Math.max(1, roomCount));
     target = {
@@ -720,8 +729,8 @@ onMounted(() => {
       </template>
       <!-- SVG连线层（内部线、外部线） -->
       <svg
-        :width="canvasDomRef?.offsetWidth || 1200"
-        :height="canvasDomRef?.offsetHeight || 800"
+        :width="canvasDomRef?.offsetWidth || 1920"
+        :height="canvasDomRef?.offsetHeight || 1080"
         style="
           position: absolute;
           top: 0;
@@ -782,7 +791,8 @@ onMounted(() => {
 <style scoped>
 .canvas-bg {
   position: relative;
-  width: 1200px; height: 800px
+  width: 1920px;
+  height: 1080px;
 }
 .canvas-bg::before {
   content: '';

--- a/apps/web-ele/src/views/control/network-topology/index.vue
+++ b/apps/web-ele/src/views/control/network-topology/index.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { nextTick, onMounted, onUnmounted, ref } from 'vue';
+import { useRouter } from 'vue-router';
 
 import html2canvas from 'html2canvas';
 
@@ -10,6 +11,8 @@ import CanvasRightPanel from './components/CanvasRightPanel.vue';
 import ExternalLines from './components/ExternalLines.vue';
 import InternalLines from './components/InternalLines.vue';
 import TopoToolbar from './components/TopoToolbar.vue';
+
+const router = useRouter();
 
 interface PortLayer {
   id: string;
@@ -336,6 +339,15 @@ function addDevice() {
   }
   newDev.parentCabinetId = null;
   devicesOnCanvas.value.push(newDev);
+}
+
+function openDeviceView(dev: RuntimeDevice) {
+  if (
+    dev.deviceId !== 'CABINET-42U' &&
+    dev.deviceId !== 'POWER-CABINET'
+  ) {
+    router.push(`/control/device-view/${dev.deviceId}`);
+  }
 }
 
 // 设备拖拽
@@ -674,6 +686,7 @@ function onKeyDown(e: KeyboardEvent) {
           class="device-wrap"
           :class="{ 'active-device': activeDeviceId === dev._uuid }"
           @click.stop="activeDeviceId = dev._uuid"
+          @dblclick.stop="openDeviceView(dev)"
           :style="{
             position: 'absolute',
             left: `${dev.position.x}px`,


### PR DESCRIPTION
## Summary
- include `apiId` and `dataKey` in new layers
- let cards choose an API and key to populate their text
- render card text using values from API responses
- fetch API data inside the canvas editor so card text updates during editing
- share API list across devices so any layer can bind to an existing API
- expose the API list in the property panel for all layers
- generic key search for API values
- tables can pull data from API by key
- cards now choose keys via dropdown instead of manual input
- allow selecting intermediate API keys
- show API URLs in dropdown selections
- add `withRedisState` prop to preview renderer and pass it from device view
- include `redisState: 1` when fetching pushed APIs
- reload device view on route changes

## Testing
- `pnpm lint` *(fails: stylelint errors)*


------
https://chatgpt.com/codex/tasks/task_e_687762a14028833086ad0db580d30a67