### PR TITLE
Fix port status map persistence

### DIFF
--- a/apps/web-ele/src/components/business/DeviceEditor/PropertyPanel.vue
+++ b/apps/web-ele/src/components/business/DeviceEditor/PropertyPanel.vue
@@ -333,6 +333,26 @@ watch(tableDataKey, () => {
   emit('update', props.config);
 });
 
+watch(portKey, () => {
+  if (!selectedLayer.value || selectedLayer.value.type !== 'port') return;
+  selectedLayer.value.config.portKey = portKey.value;
+  emit('update', props.config);
+});
+
+watch(
+  statusList,
+  (list) => {
+    if (!selectedLayer.value || selectedLayer.value.type !== 'port') return;
+    const mapping: Record<number | string, any> = {};
+    for (const row of list) {
+      mapping[row.value] = { iconUrl: row.iconUrl, label: row.label };
+    }
+    selectedLayer.value.config.statusMapping = mapping;
+    emit('update', props.config);
+  },
+  { deep: true },
+);
+
 watch(cardDataKey, () => {
   if (!selectedLayer.value || selectedLayer.value.type !== 'card') return;
   selectedLayer.value.config.dataKey = cardDataKey.value;


### PR DESCRIPTION
## Summary
- sync portKey and statusList back to layer config automatically so copied ports retain status mapping

## Testing
- `pnpm lint` *(fails: stylelint errors)*
- `pnpm test:unit`

------
https://chatgpt.com/codex/tasks/task_e_687c5b79d4ac8330b22de376709f03c2