### PR TITLE
Add reuse button to device editor

### DIFF
--- a/apps/web-ele/src/components/business/DeviceEditor/CanvasEditor.vue
+++ b/apps/web-ele/src/components/business/DeviceEditor/CanvasEditor.vue
@@ -165,10 +165,13 @@ function onDragOver(e: DragEvent) {
 }
 function onDrop(e: DragEvent) {
   e.preventDefault();
-  // 画布左上的实际 offset（考虑刻度的 32px 偏移）
+  // 画布左上的实际 offset，并考虑缩放比例
   const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
-  const x = e.clientX - rect.left;
-  const y = e.clientY - rect.top;
+  const scaleX = rect.width / props.config.width;
+  const scaleY = rect.height / props.config.height;
+  const scale = Math.min(scaleX || 1, scaleY || 1);
+  const x = (e.clientX - rect.left) / scale;
+  const y = (e.clientY - rect.top) / scale;
   const url = e.dataTransfer?.getData('image-url');
   const matType = e.dataTransfer?.getData('mat-type') || 'image'; // 关键：识别类型
   let layer;
@@ -257,6 +260,8 @@ function onDrop(e: DragEvent) {
   }
   if (layer) {
     props.config.layers.push(layer);
+    selectedId.value = layer.id;
+    emit('select', layer.id);
     emit('update', JSON.parse(JSON.stringify(props.config)));
   }
 }

--- a/apps/web-ele/src/components/business/DeviceEditor/PalettePanel.vue
+++ b/apps/web-ele/src/components/business/DeviceEditor/PalettePanel.vue
@@ -57,7 +57,11 @@ function initFolderTree() {
       : JSON.parse(JSON.stringify(defaultFolderTree));
 }
 onMounted(initFolderTree);
-watch(() => props.config?.materialsTree, initFolderTree, { immediate: true });
+watch(
+  () => JSON.stringify(props.config?.materialsTree || []),
+  initFolderTree,
+  { immediate: true },
+);
 
 // ========== 业务逻辑不变 ==========
 const selectedFolderId = ref('root');


### PR DESCRIPTION
## Summary
- track last loaded device in DeviceEditor
- add `handleReuseDevice` to copy previous device configs
- add **复用设备** button to toolbar
- allow height input in PropertyPanel
- enable dynamic port settings for image layers
- add JSON import/export helpers for full device configs
- preserve state mapping icons when changing port key
- fix material drop position scaling and auto-select new layer
- avoid losing palette items when editing layers
- sync API push settings to all layers
- fix ws push settings
- unify WebSocket toggle on API entries
- fix API push settings persisting across reloads
- ensure push flags persist when saving or reusing devices
- disable polling when WebSocket push is enabled
- show port name when hovering over a port
- show port IP in preview tooltip
- highlight existing IPs red by checking `listByIps` API

## Testing
- `pnpm test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687da1cff2f48330b277a40f5a54a143