### PR TITLE
Add table column options to preview

### DIFF
--- a/apps/web-ele/src/components/business/DeviceEditor/CanvasEditor.vue
+++ b/apps/web-ele/src/components/business/DeviceEditor/CanvasEditor.vue
@@ -7,6 +7,7 @@ import {
   ref,
   watch,
 } from 'vue';
+import { parseSnmpContent } from '@vben/utils';
 
 const props = defineProps<{
   config: any;
@@ -129,22 +130,34 @@ function getByKey(obj: any, path: string): any {
 }
 
 function getTableData(layer: any) {
+  let data: any;
   if (layer.config.apiId) {
     const apiResp = apiDataMap.value[layer.config.apiId];
     if (!apiResp || apiResp.error) return [];
-    let data = layer.config.dataKey ? getByKey(apiResp, layer.config.dataKey) : apiResp;
-    if (Array.isArray(data)) return data;
-    if (Array.isArray(data?.data)) return data.data;
-    if (Array.isArray(data?.rows)) return data.rows;
-    return [];
+    data = layer.config.dataKey ? getByKey(apiResp, layer.config.dataKey) : apiResp;
+  } else {
+    data = layer.config.data;
   }
-  return Array.isArray(layer.config.data) ? layer.config.data : [];
+  if (Array.isArray(data)) return data;
+  if (Array.isArray(data?.data)) return data.data;
+  if (Array.isArray(data?.rows)) return data.rows;
+  if (data && typeof data === 'object') return parseSnmpContent(data);
+  return [];
+}
+
+function getTableColumns(layer: any) {
+  if (Array.isArray(layer.config.columns) && layer.config.columns.length) {
+    return layer.config.columns;
+  }
+  const data = getTableData(layer);
+  if (Array.isArray(data) && data.length) {
+    return Object.keys(data[0]).map((k) => ({ field: k, title: k }));
+  }
+  return [];
 }
 
 function getTableHeaders(layer: any) {
-  const data = getTableData(layer);
-  if (Array.isArray(data) && data.length) return Object.keys(data[0]);
-  return [];
+  return getTableColumns(layer).map((c: any) => c.title || c.field);
 }
 
 function getLayerText(layer: any) {
@@ -514,6 +527,7 @@ watch(
             width: `${layer.config.width}px`,
             height: `${layer.config.height}px`,
             zIndex: layer.zIndex,
+            fontSize: layer.config.fontSize || '11px',
             outline: selectedId === layer.id ? '2px solid #1976d2' : '',
             boxShadow: selectedId === layer.id ? '0 0 0 3px #90caf9aa' : '',
             overflowX: 'auto',
@@ -524,26 +538,29 @@ watch(
           draggable="false"
           @dragstart.prevent
         >
-          <table class="w-full border-collapse text-[11px]">
-            <thead v-if="getTableHeaders(layer).length">
+          <table class="w-full border-collapse">
+            <thead
+              v-if="getTableColumns(layer).length"
+              :style="{ lineHeight: layer.config.headerSize || undefined }"
+            >
               <tr>
                 <th
-                  v-for="key in getTableHeaders(layer)"
-                  :key="key"
+                  v-for="col in getTableColumns(layer)"
+                  :key="col.field"
                   class="border px-1 py-0.5"
                 >
-                  {{ key }}
+                  {{ col.title || col.field }}
                 </th>
               </tr>
             </thead>
             <tbody>
               <tr v-for="(row, rIdx) in getTableData(layer)" :key="rIdx">
                 <td
-                  v-for="key in getTableHeaders(layer)"
-                  :key="key"
+                  v-for="col in getTableColumns(layer)"
+                  :key="col.field"
                   class="border px-1 py-0.5"
                 >
-                  {{ row[key] }}
+                  {{ row[col.field] }}
                 </td>
               </tr>
             </tbody>

--- a/apps/web-ele/src/components/business/DeviceEditor/PropertyPanel.vue
+++ b/apps/web-ele/src/components/business/DeviceEditor/PropertyPanel.vue
@@ -182,6 +182,9 @@ const tableDataStr = ref('');
 const tableApiId = ref('');
 const tableScrollY = ref(false);
 const tableDataKey = ref('');
+const tableHeaderSize = ref('');
+const tableFontSize = ref('');
+const tableColumnsStr = ref('');
 
 // ----- 卡片配置 -----
 const cardText = ref('文本');
@@ -291,9 +294,22 @@ function handleSaveTable() {
     alert('JSON 格式错误');
     return;
   }
+  let columns: any = [];
+  if (tableColumnsStr.value) {
+    try {
+      columns = JSON.parse(tableColumnsStr.value);
+      if (!Array.isArray(columns)) throw new Error();
+    } catch {
+      alert('列配置 JSON 格式错误');
+      return;
+    }
+  }
   selectedLayer.value.config.apiId = tableApiId.value;
   selectedLayer.value.config.dataKey = tableDataKey.value;
   selectedLayer.value.config.scrollY = tableScrollY.value;
+  selectedLayer.value.config.columns = columns;
+  selectedLayer.value.config.headerSize = tableHeaderSize.value;
+  selectedLayer.value.config.fontSize = tableFontSize.value;
   emit('update', props.config);
   alert('属性已保存！');
 }
@@ -396,11 +412,13 @@ watch(tableApiId, () => {
 watch(selectedApiId, () => {
   const api = availableApis.value.find((a) => a.id === selectedApiId.value);
   if (api && api.lastSample) {
+    testResult.value = api.lastSample;
     portMap.value = extractPortMap(api.lastSample);
     const keys = Object.keys(portMap.value);
     portKey.value = keys[0] || '';
     updateStatusList();
   } else {
+    testResult.value = null;
     portMap.value = {};
     portKey.value = '';
     statusList.value = [];
@@ -441,6 +459,8 @@ watch(tableApiId, () => {
   selectedLayer.value.config.apiId = tableApiId.value;
   const opts = getKeyOptions(tableApiId.value);
   if (!tableDataKey.value && opts.length) tableDataKey.value = opts[0];
+  const api = availableApis.value.find((a) => a.id === tableApiId.value);
+  testResult.value = api?.lastSample || null;
   emit('update', props.config);
 });
 
@@ -448,6 +468,28 @@ watch(tableScrollY, () => {
   if (!selectedLayer.value || selectedLayer.value.type !== 'table') return;
   selectedLayer.value.config.scrollY = tableScrollY.value;
   emit('update', props.config);
+});
+
+watch(tableHeaderSize, () => {
+  if (!selectedLayer.value || selectedLayer.value.type !== 'table') return;
+  selectedLayer.value.config.headerSize = tableHeaderSize.value;
+  emit('update', props.config);
+});
+
+watch(tableFontSize, () => {
+  if (!selectedLayer.value || selectedLayer.value.type !== 'table') return;
+  selectedLayer.value.config.fontSize = tableFontSize.value;
+  emit('update', props.config);
+});
+
+watch(tableColumnsStr, () => {
+  if (!selectedLayer.value || selectedLayer.value.type !== 'table') return;
+  try {
+    const cols = tableColumnsStr.value ? JSON.parse(tableColumnsStr.value) : [];
+    if (!Array.isArray(cols) && tableColumnsStr.value) return;
+    selectedLayer.value.config.columns = cols;
+    emit('update', props.config);
+  } catch {}
 });
 
 watch(tableDataKey, () => {
@@ -511,6 +553,11 @@ watch(
       : '';
     tableDataKey.value = layer.type === 'table' ? layer.config.dataKey || '' : '';
     tableScrollY.value = layer.type === 'table' ? !!layer.config.scrollY : false;
+    tableHeaderSize.value = layer.type === 'table' ? layer.config.headerSize || '' : '';
+    tableFontSize.value = layer.type === 'table' ? layer.config.fontSize || '' : '';
+    tableColumnsStr.value = layer.type === 'table'
+      ? JSON.stringify(layer.config.columns || [], null, 2)
+      : '';
 
     cardText.value = layer.type === 'card' ? layer.config.text || '文本' : '文本';
     cardFontSize.value = layer.type === 'card' ? layer.config.fontSize || 14 : 14;
@@ -529,8 +576,10 @@ watch(
 
     const api = availableApis.value.find(a => a.id === selectedApiId.value);
     if (api && api.lastSample) {
+      testResult.value = api.lastSample;
       portMap.value = extractPortMap(api.lastSample);
     } else {
+      testResult.value = null;
       portMap.value = {};
     }
   },
@@ -711,13 +760,29 @@ watch(
             </select>
           </div>
           <div class="mb-2">
+            <label>表头高度：</label>
+            <input v-model="tableHeaderSize" class="w-24 border p-1" placeholder="如 2.4em" />
+          </div>
+          <div class="mb-2">
+            <label>字体大小：</label>
+            <input v-model="tableFontSize" class="w-24 border p-1" placeholder="如 14px" />
+          </div>
+          <div class="mb-2">
             <label>
               <input type="checkbox" v-model="tableScrollY" /> 启用纵向滚动
             </label>
           </div>
           <div class="mb-2">
+            <label class="mb-1 block">列配置(JSON)：</label>
+            <textarea v-model="tableColumnsStr" rows="2" class="w-full border p-1 text-xs"></textarea>
+          </div>
+          <div class="mb-2">
             <label class="mb-1 block">静态 JSON 数据：</label>
             <textarea v-model="tableDataStr" rows="4" class="w-full border p-1 text-xs"></textarea>
+          </div>
+          <div v-if="testResult" class="mb-2">
+            <label class="mb-1 block">接口返回：</label>
+            <pre class="max-h-40 overflow-auto bg-[#1e1e1e] p-1 text-xs text-white">{{ JSON.stringify(testResult, null, 2) }}</pre>
           </div>
           <button class="mt-2 rounded border px-3 py-1" @click="handleSaveTable">保存配置</button>
         </div>

--- a/docs/src/components/common-ui/vben-vxe-table.md
+++ b/docs/src/components/common-ui/vben-vxe-table.md
@@ -258,6 +258,8 @@ useVbenVxeGrid 返回的第二个参数，是一个对象，包含了一些表�
 | formOptions | 表单参数 | `VbenFormProps` | - |
 | showSearchForm | 是否显示搜索表单 | `boolean` | - |
 | separator | 搜索表单与表格主体之间的分隔条 | `boolean\|SeparatorOptions` | >5.5.4 |
+| headerSize | 表头高度 | `string` | >5.5.4 |
+| fontSize | 表格字体大小 | `string` | >5.5.4 |
 
 ## Slots
 

--- a/packages/effects/plugins/src/vxe-table/api.ts
+++ b/packages/effects/plugins/src/vxe-table/api.ts
@@ -23,6 +23,8 @@ function getDefaultState(): VxeGridProps {
     gridEvents: {},
     formOptions: undefined,
     showSearchForm: true,
+    headerSize: undefined,
+    fontSize: undefined,
   };
 }
 

--- a/packages/effects/plugins/src/vxe-table/style.css
+++ b/packages/effects/plugins/src/vxe-table/style.css
@@ -32,6 +32,8 @@
   /* table */
   --vxe-ui-table-header-background-color: hsl(var(--accent));
   --vxe-ui-table-border-color: hsl(var(--border));
+  --vben-vxe-header-size: 2.2em;
+  --vben-vxe-font-size: 0.875rem;
   --vxe-ui-table-row-hover-background-color: hsl(var(--accent-hover));
   --vxe-ui-table-row-striped-background-color: hsl(var(--accent) / 60%);
   --vxe-ui-table-row-hover-striped-background-color: hsl(var(--accent));
@@ -114,4 +116,12 @@
 
 .vxe-grid--layout-body-content-wrapper {
   overflow: hidden;
+}
+
+.vxe-header--row {
+  line-height: var(--vben-vxe-header-size);
+}
+.vxe-header--column,
+.vxe-body--column {
+  font-size: var(--vben-vxe-font-size);
 }

--- a/packages/effects/plugins/src/vxe-table/types.ts
+++ b/packages/effects/plugins/src/vxe-table/types.ts
@@ -72,6 +72,10 @@ export interface VxeGridProps {
    * 搜索表单与表格主体之间的分隔条
    */
   separator?: boolean | SeparatorOptions;
+  /** 表头高度，css单位 */
+  headerSize?: string;
+  /** 表格字体大小，css单位 */
+  fontSize?: string;
 }
 
 export type ExtendedVxeGridApi = VxeGridApi & {

--- a/packages/effects/plugins/src/vxe-table/use-vxe-grid.vue
+++ b/packages/effects/plugins/src/vxe-table/use-vxe-grid.vue
@@ -74,6 +74,8 @@ const {
   tableTitleHelp,
   showSearchForm,
   separator,
+  headerSize,
+  fontSize,
 } = usePriorityValues(props, state);
 
 const { isMobile } = usePreferences();
@@ -337,6 +339,13 @@ const isCompactForm = computed(() => {
   return formApi.getState()?.compact;
 });
 
+const gridStyle = computed(() => {
+  return {
+    ...(headerSize.value ? { '--vben-vxe-header-size': headerSize.value } : {}),
+    ...(fontSize.value ? { '--vben-vxe-font-size': fontSize.value } : {}),
+  };
+});
+
 onMounted(() => {
   props.api?.mount?.(gridRef.value, formApi);
   init();
@@ -349,7 +358,7 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <div :class="cn('bg-card h-full rounded-md', className)">
+  <div :class="cn('bg-card h-full rounded-md', className)" :style="gridStyle">
     <VxeGrid
       ref="gridRef"
       :class="

--- a/packages/utils/src/helpers/index.ts
+++ b/packages/utils/src/helpers/index.ts
@@ -6,3 +6,4 @@ export * from './get-popup-container';
 export * from './merge-route-modules';
 export * from './reset-routes';
 export * from './unmount-global-loading';
+export * from './parse-snmp-content';

--- a/packages/utils/src/helpers/parse-snmp-content.ts
+++ b/packages/utils/src/helpers/parse-snmp-content.ts
@@ -1,0 +1,32 @@
+export interface SnmpContentEntry {
+  index: number;
+  key: string;
+  value: any;
+}
+
+/**
+ * Convert SNMP style structures into simple table rows.
+ */
+export function parseSnmpContent(data: any): SnmpContentEntry[] {
+  if (!data) return [];
+
+  const source = data.data ?? data;
+
+  if (Array.isArray(source)) return source;
+  if (Array.isArray(source.jsonKeyValue)) return source.jsonKeyValue;
+
+  const content =
+    source.jsonValue?.content ?? source.jsonValue ?? source.content ?? source;
+
+  if (Array.isArray(content)) return content;
+
+  if (content && typeof content === 'object') {
+    return Object.entries(content).map(([key, value], idx) => ({
+      index: idx,
+      key,
+      value,
+    }));
+  }
+
+  return [];
+}

--- a/playground/src/locales/langs/en-US/examples.json
+++ b/playground/src/locales/langs/en-US/examples.json
@@ -31,6 +31,7 @@
     "tree": "Tree Table",
     "fixed": "Fixed Header/Column",
     "virtual": "Virtual Scroll",
+    "snmpContent": "SNMP Content",
     "editCell": "Edit Cell",
     "editRow": "Edit Row",
     "custom-cell": "Custom Cell",

--- a/playground/src/locales/langs/zh-CN/examples.json
+++ b/playground/src/locales/langs/zh-CN/examples.json
@@ -34,6 +34,7 @@
     "tree": "树形表格",
     "fixed": "固定表头/列",
     "virtual": "虚拟滚动",
+    "snmpContent": "SNMP 表格",
     "editCell": "单元格编辑",
     "editRow": "行编辑",
     "custom-cell": "自定义单元格",

--- a/playground/src/router/routes/modules/examples.ts
+++ b/playground/src/router/routes/modules/examples.ts
@@ -168,6 +168,14 @@ const routes: RouteRecordRaw[] = [
               title: $t('examples.vxeTable.virtual'),
             },
           },
+          {
+            name: 'VxeTableSnmpContentExample',
+            path: '/examples/vxe-table/snmp-content',
+            component: () => import('#/views/examples/vxe-table/snmp-content.vue'),
+            meta: {
+              title: $t('examples.vxeTable.snmpContent'),
+            },
+          },
         ],
       },
       {

--- a/playground/src/views/examples/vxe-table/snmp-content.vue
+++ b/playground/src/views/examples/vxe-table/snmp-content.vue
@@ -1,0 +1,41 @@
+<script lang="ts" setup>
+import type { VxeGridProps } from '#/adapter/vxe-table';
+
+import { Page } from '@vben/common-ui';
+import { useVbenVxeGrid } from '#/adapter/vxe-table';
+import { parseSnmpContent } from '@vben/utils';
+
+const rawData = {
+  content: {
+    '1.0.8802.1.1.2.1.4.1.1.7.0.28.1': 'Ethernet0/0/24',
+    '1.0.8802.1.1.2.1.4.1.1.10.0.28.1': 'DeviceModel',
+    '1.0.8802.1.1.2.1.4.1.1.5.0.28.1': '84:ad:58:f7:2d:1b',
+  },
+};
+
+const tableData = parseSnmpContent(rawData);
+
+const gridOptions: VxeGridProps<{
+  index: number;
+  key: string;
+  value: string;
+}> = {
+  columns: [
+    { field: 'value', title: 'Value' },
+  ],
+  data: tableData,
+  height: 'auto',
+};
+
+const [Grid] = useVbenVxeGrid({
+  gridOptions,
+  headerSize: '2.6em',
+  fontSize: '14px',
+});
+</script>
+
+<template>
+  <Page title="SNMP Content">
+    <Grid />
+  </Page>
+</template>


### PR DESCRIPTION
## Summary
- support custom column definitions when rendering tables
- apply table header and font size settings
- parse SNMP style objects during preview
- handle `jsonKeyValue` arrays when parsing SNMP content
- extend SNMP parser to detect nested `jsonValue` fields
- simplify SNMP parser implementation

## Testing
- `pnpm run lint` *(fails: vsh not found)*
- `pnpm run test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f1541651c8330a92f30b9d09b73f4