### PR TITLE
Extract port 9000 IPs to env files

### DIFF
--- a/apps/web-ele/.env
+++ b/apps/web-ele/.env
@@ -6,3 +6,7 @@ VITE_APP_NAMESPACE=vben-web-ele
 
 # 对store进行加密的密钥，在将store持久化到localStorage时会使用该密钥进行加密
 VITE_APP_STORE_SECURE_KEY=please-replace-me-with-your-own-key
+
+# Base url used for built-in port icons
+# Example: http://192.168.59.229:9000
+VITE_PORT_ICON_BASE=

--- a/apps/web-ele/.env.analyze
+++ b/apps/web-ele/.env.analyze
@@ -5,3 +5,6 @@ VITE_BASE=/
 VITE_GLOB_API_URL=/api
 
 VITE_VISUALIZER=true
+
+# Base url used for built-in port icons
+VITE_PORT_ICON_BASE=

--- a/apps/web-ele/.env.development
+++ b/apps/web-ele/.env.development
@@ -17,3 +17,5 @@ VITE_INJECT_APP_LOADING=true
 
 
 VITE_MINIO_BASE=http://192.168.1.99:9000
+# Base url used for built-in port icons
+VITE_PORT_ICON_BASE=http://192.168.59.229:9000

--- a/apps/web-ele/.env.production
+++ b/apps/web-ele/.env.production
@@ -17,3 +17,6 @@ VITE_INJECT_APP_LOADING=true
 
 # 打包后是否生成dist.zip
 VITE_ARCHIVER=true
+
+# Base url used for built-in port icons
+VITE_PORT_ICON_BASE=

--- a/apps/web-ele/src/components/business/DeviceEditor/PalettePanel.vue
+++ b/apps/web-ele/src/components/business/DeviceEditor/PalettePanel.vue
@@ -9,7 +9,7 @@ const props = defineProps<{
   config: any;
 }>();
 
-const PORT_ICON_URL = 'http://192.168.59.229:9000/qiuqiu/green.gif';
+const PORT_ICON_URL = `${import.meta.env.VITE_PORT_ICON_BASE}/qiuqiu/green.gif`;
 const TABLE_ICON_URL =
   'data:image/svg+xml,%3Csvg xmlns%3D"http://www.w3.org/2000/svg" width%3D"56" height%3D"56"%3E%3Crect x%3D"1" y%3D"1" width%3D"54" height%3D"54" fill%3D"%23fff" stroke%3D"%23ccc"/%3E%3Cline x1%3D"1" y1%3D"19" x2%3D"55" y2%3D"19" stroke%3D"%23ccc"/%3E%3Cline x1%3D"1" y1%3D"37" x2%3D"55" y2%3D"37" stroke%3D"%23ccc"/%3E%3Cline x1%3D"19" y1%3D"1" x2%3D"19" y2%3D"55" stroke%3D"%23ccc"/%3E%3Cline x1%3D"37" y1%3D"1" x2%3D"37" y2%3D"55" stroke%3D"%23ccc"/%3E%3C/svg%3E';
 const CARD_ICON_URL =

--- a/apps/web-ele/src/views/control/device-editor/index.vue
+++ b/apps/web-ele/src/views/control/device-editor/index.vue
@@ -161,7 +161,7 @@ onUnmounted(() => editorWrapRef.value?.removeEventListener('wheel', handleWheel)
 /* -------------------------------------------------------------------------- */
 /* 素材图标                                                                    */
 /* -------------------------------------------------------------------------- */
-const PORT_ICON_URL = 'http://192.168.59.229:9000/qiuqiu/green.gif';
+const PORT_ICON_URL = `${import.meta.env.VITE_PORT_ICON_BASE}/qiuqiu/green.gif`;
 const TABLE_ICON_URL = 'data:image/svg+xml,...';
 const CARD_ICON_URL = 'data:image/svg+xml,...';
 


### PR DESCRIPTION
## Summary
- move hard-coded port 9000 hosts into env files
- reference the new `VITE_PORT_ICON_BASE` variable from components
- keep current Minio config untouched

## Testing
- `pnpm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_688ac5c785b88330964fc8417709d609