### PR TITLE
feat: add advanced port mapping component

### DIFF
--- a/apps/web-ele/src/components/business/DeviceDisplay/DeviceDisplay.vue
+++ b/apps/web-ele/src/components/business/DeviceDisplay/DeviceDisplay.vue
@@ -7,6 +7,8 @@ import { computed } from 'vue';
 import IconsLayer from '../layers/IconsLayer.vue';
 import ImageLayer from '../layers/ImageLayer.vue';
 import PortsLayer from '../layers/PortsLayer.vue';
+import PortComponent from '../ports/PortComponent.vue';
+import PortAdvRenderer from '../ports/PortAdvRenderer.vue';
 
 defineProps<{
   config: DeviceConfig;
@@ -16,6 +18,8 @@ const layerComponentMap = {
   image: ImageLayer,
   ports: PortsLayer,
   icons: IconsLayer,
+  port: PortComponent,
+  'port-adv': PortAdvRenderer,
 } as const;
 
 const orderedLayers = computed(() =>

--- a/apps/web-ele/src/components/business/DeviceEditor/CanvasEditor.vue
+++ b/apps/web-ele/src/components/business/DeviceEditor/CanvasEditor.vue
@@ -241,12 +241,12 @@ function onDrop(e: DragEvent) {
         type: 'port',
         zIndex: layers.value.length + 1,
         name: `端口-${Date.now().toString().slice(-4)}`,
-      config: {
-        x: x - 20,
-        y: y - 20,
-        width: 32,
-        height: 32,
-        src: url,
+        config: {
+          x: x - 20,
+          y: y - 20,
+          width: 32,
+          height: 32,
+          src: url,
           // 下面可扩展端口相关配置
           rotate: 0,
           dynamic: false, // 默认不开启动态端口
@@ -256,22 +256,44 @@ function onDrop(e: DragEvent) {
           dataKey: '',
         },
       };
+    } else if (matType === 'port-adv') {
+      // 拖入高级端口组件
+      layer = {
+        id: `port-adv-${Date.now()}`,
+        type: 'port-adv',
+        zIndex: layers.value.length + 1,
+        name: `高级端口-${Date.now().toString().slice(-4)}`,
+        config: {
+          x: x - 20,
+          y: y - 20,
+          width: 32,
+          height: 32,
+          src: url,
+          rotate: 0,
+          apiId: '',
+          portDataKey: '',
+          portKey: '',
+          statusMapping: {},
+          usePush: false,
+          pushService: '',
+        },
+      };
     } else {
       // 普通图片
       layer = {
         id: `img-${Date.now()}`,
         type: 'image',
         zIndex: layers.value.length + 1,
-      config: {
-        x: x - 40,
-        y: y - 40,
-        width: 120,
-        height: 80,
-        src: url,
-        rotate: 0,
-        apiId: '',
-        dataKey: '',
-      },
+        config: {
+          x: x - 40,
+          y: y - 40,
+          width: 120,
+          height: 80,
+          src: url,
+          rotate: 0,
+          apiId: '',
+          dataKey: '',
+        },
       };
     }
   }

--- a/apps/web-ele/src/components/business/DeviceEditor/PalettePanel.vue
+++ b/apps/web-ele/src/components/business/DeviceEditor/PalettePanel.vue
@@ -30,6 +30,13 @@ const defaultFolderTree = [
         isBuiltIn: true,
       },
       {
+        id: 'port-adv-default',
+        url: PORT_ICON_URL,
+        name: '高级端口',
+        type: 'port-adv',
+        isBuiltIn: true,
+      },
+      {
         id: 'table-default',
         url: TABLE_ICON_URL,
         name: '表格',
@@ -287,7 +294,7 @@ defineExpose({
               {{ mat.name }}
             </div>
             <div
-              v-if="mat.type === 'port'"
+              v-if="mat.type === 'port' || mat.type === 'port-adv'"
               style="font-size: 10px; color: #39e1e7"
             >
               端口

--- a/apps/web-ele/src/components/business/ports/PortAdvRenderer.vue
+++ b/apps/web-ele/src/components/business/ports/PortAdvRenderer.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useDeviceStore } from '#/store/deviceStore';
+
+// config: { x, y, width, height, apiId, portDataKey, portKey, statusMapping }
+const props = defineProps<{ config: any }>();
+
+const store = useDeviceStore();
+
+function getByPath(obj: any, path: string) {
+  return path
+    .split('.')
+    .reduce((o: any, k: string) => (o && typeof o === 'object' ? o[k] : undefined), obj);
+}
+
+const stateValue = computed(() => {
+  const data = (store.status as any) || {};
+  const apiData = props.config.portDataKey ? getByPath(data, props.config.portDataKey) : data;
+  if (apiData && typeof apiData === 'object') {
+    return apiData[props.config.portKey || ''];
+  }
+  return undefined;
+});
+
+const iconUrl = computed(() => {
+  const mapping = props.config.statusMapping || {};
+  const key = stateValue.value;
+  return mapping[String(key)]?.iconUrl || '/imgs/port-gray.png';
+});
+</script>
+
+<template>
+  <img
+    :src="iconUrl"
+    :style="{ left: `${config.x}px`, top: `${config.y}px` }"
+    class="absolute pointer-events-none select-none"
+    draggable="false"
+  />
+</template>

--- a/apps/web-ele/src/models/device.ts
+++ b/apps/web-ele/src/models/device.ts
@@ -4,7 +4,7 @@
 export interface LayerBase {
   id: string;
   name: string;
-  type: 'custom' | 'icons' | 'image' | 'ports';
+  type: 'custom' | 'icons' | 'image' | 'ports' | 'port' | 'port-adv';
   visible: boolean;
   zIndex: number;
   config: any;


### PR DESCRIPTION
## Summary
- add PortAdvRenderer for advanced port mapping
- support new `port-adv` type in editor panels and canvas
- include advanced port default entry in palette and layer map

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68959b578580833095ef3cb7b878e599