### PR TITLE
fix(web-ele): support array-indexed ports with status mapping

### DIFF
--- a/apps/web-ele/src/components/business/DeviceEditor/PropertyPanel.vue
+++ b/apps/web-ele/src/components/business/DeviceEditor/PropertyPanel.vue
@@ -250,7 +250,7 @@ function updateStatusList() {
   if (!portMap.value || !Object.keys(portMap.value).length) return;
 
   const prevRows = new Map(
-    statusList.value.map((row) => [row.value, { label: row.label, iconUrl: row.iconUrl }]),
+    statusList.value.map((row) => [String(row.value), { label: row.label, iconUrl: row.iconUrl }]),
   );
   const cfgMap =
     (selectedLayer.value && selectedLayer.value.config.statusMapping) || ({} as Record<string, any>);
@@ -260,7 +260,7 @@ function updateStatusList() {
     ...Object.values(portMap.value),
     ...statusList.value.map((r) => r.value),
   ];
-  const uniq = Array.from(new Set(values));
+  const uniq = Array.from(new Set(values.map((v) => String(v))));
 
   statusList.value = uniq.map((v) => ({
     value: v,
@@ -307,7 +307,7 @@ async function handleUploadIcon(e: Event, idx: number) {
 // ======== 高级端口：状态映射与图标 ========
 function updateAdvStatusList() {
   const prev = new Map(
-    advStatusList.value.map((row) => [row.value, { label: row.label, iconUrl: row.iconUrl }]),
+    advStatusList.value.map((row) => [String(row.value), { label: row.label, iconUrl: row.iconUrl }]),
   );
   const cfgMap =
     (selectedLayer.value && selectedLayer.value.config.statusMapping) || ({} as Record<string, any>);
@@ -327,7 +327,7 @@ function updateAdvStatusList() {
 
   // 合并手动添加的状态值，避免保存后丢失
   values.push(...advStatusList.value.map((r) => r.value));
-  const uniq = Array.from(new Set(values));
+  const uniq = Array.from(new Set(values.map((v) => String(v))));
 
   advStatusList.value = uniq.map((v) => ({
     value: v,

--- a/apps/web-ele/src/components/business/DeviceEditor/PropertyPanel.vue
+++ b/apps/web-ele/src/components/business/DeviceEditor/PropertyPanel.vue
@@ -494,21 +494,28 @@ function updateAdvPortMap() {
     if (data && typeof data === 'object') {
       advPortMap.value = data;
       const keys = Object.keys(data);
-      advPortKey.value = keys[0] || '';
-      updateAdvStatusList();
+      advPortKey.value = advPortKey.value && keys.includes(advPortKey.value)
+        ? advPortKey.value
+        : keys[0] || '';
+    } else if (data !== undefined) {
+      advPortMap.value = { value: data } as Record<string, any>;
+      advPortKey.value = 'value';
     } else {
       advPortMap.value = {};
-      advStatusList.value = [];
+      advPortKey.value = '';
     }
+    updateAdvStatusList();
   } else {
     advTestResult.value = null;
     advPortMap.value = {};
+    advPortKey.value = '';
     advStatusList.value = [];
   }
 }
 
 watch(advApiId, updateAdvPortMap);
 watch(advPortDataKey, updateAdvPortMap);
+watch(advPortKey, updateAdvStatusList);
 
 watch(dynamicPort, () => {
   if (!selectedLayer.value) return;
@@ -686,10 +693,25 @@ watch(
         const data = advPortDataKey.value
           ? getValueByPath(apiAdv.lastSample, advPortDataKey.value)
           : extractPortMap(apiAdv.lastSample);
-        advPortMap.value = data && typeof data === 'object' ? data : {};
+        if (data && typeof data === 'object') {
+          advPortMap.value = data;
+          const keys = Object.keys(data);
+          advPortKey.value = advPortKey.value && keys.includes(advPortKey.value)
+            ? advPortKey.value
+            : keys[0] || '';
+        } else if (data !== undefined) {
+          advPortMap.value = { value: data } as Record<string, any>;
+          advPortKey.value = 'value';
+        } else {
+          advPortMap.value = {};
+          advPortKey.value = '';
+        }
+        updateAdvStatusList();
       } else {
         advTestResult.value = null;
         advPortMap.value = {};
+        advPortKey.value = '';
+        advStatusList.value = [];
       }
     }
   },

--- a/apps/web-ele/src/components/business/ports/PortAdvRenderer.vue
+++ b/apps/web-ele/src/components/business/ports/PortAdvRenderer.vue
@@ -29,9 +29,10 @@ const stateValue = computed(() => {
   const data = (store.status as any) || {};
   const apiData = props.config.portDataKey ? getByPath(data, props.config.portDataKey) : data;
   if (apiData && typeof apiData === 'object') {
-    return apiData[props.config.portKey || ''];
+    if (props.config.portKey) return apiData[props.config.portKey];
+    return undefined;
   }
-  return undefined;
+  return apiData;
 });
 
 const iconUrl = computed(() => {

--- a/apps/web-ele/src/components/business/ports/PortAdvRenderer.vue
+++ b/apps/web-ele/src/components/business/ports/PortAdvRenderer.vue
@@ -8,9 +8,21 @@ const props = defineProps<{ config: any }>();
 const store = useDeviceStore();
 
 function getByPath(obj: any, path: string) {
-  return path
+  const keys = path
+    .replace(/\[(\d+)\]/g, '.$1')
     .split('.')
-    .reduce((o: any, k: string) => (o && typeof o === 'object' ? o[k] : undefined), obj);
+    .filter(Boolean);
+  return keys.reduce((o: any, k: string) => {
+    if (o && typeof o === 'object') {
+      if (Array.isArray(o)) {
+        const idx = Number(k);
+        if (!Number.isNaN(idx)) return o[idx];
+        return o.length ? o[0][k] : undefined;
+      }
+      return o[k];
+    }
+    return undefined;
+  }, obj);
 }
 
 const stateValue = computed(() => {

--- a/apps/web-ele/src/views/control/device-preview/DevicePreviewRender.vue
+++ b/apps/web-ele/src/views/control/device-preview/DevicePreviewRender.vue
@@ -171,10 +171,10 @@ function getAdvPortStatus(layer: any) {
   if (!apiResp || apiResp.error) return null;
   const data = portDataKey ? getValueByPath(apiResp, portDataKey) : apiResp;
   if (data && typeof data === 'object') {
-    const val = (data as any)[portKey];
+    const val = portKey ? (data as any)[portKey] : undefined;
     return statusMapping[val] || null;
   }
-  return null;
+  return statusMapping[data] || null;
 }
 function bindDeviceIdToApis() {
   const deviceId = props.config?.deviceId;

--- a/apps/web-ele/src/views/control/network-topology/index.vue
+++ b/apps/web-ele/src/views/control/network-topology/index.vue
@@ -16,13 +16,14 @@ const router = useRouter();
 
 interface PortLayer {
   id: string;
-  type: 'port';
+  type: 'port' | 'port-adv';
   config: {
     height: number;
-    src: string;
     width: number;
     x: number;
     y: number;
+    src?: string;
+    [key: string]: any;
   };
 }
 interface ImageLayer {
@@ -779,7 +780,7 @@ function onKeyDown(e: KeyboardEvent) {
             />
             <!-- 端口层 -->
             <div
-              v-for="port in (dev.layers || []).filter((l) => l.type === 'port')"
+              v-for="port in (dev.layers || []).filter((l) => l.type === 'port' || l.type === 'port-adv')"
               :key="port.id"
               class="port-spot"
               :class="[
@@ -805,7 +806,7 @@ function onKeyDown(e: KeyboardEvent) {
               @click.stop="onPortClick(dev._uuid, port.id)"
             >
               <img
-                :src="port.config.src"
+                :src="port.config.src || '/imgs/port-gray.png'"
                 style="width: 100%; height: 100%"
                 draggable="false"
               />


### PR DESCRIPTION
## Summary
- parse bracket notation in advanced port renderer to read array indices
- render port-adv layers in device preview and honor status mapping for array paths

## Testing
- `pnpm lint apps/web-ele` (fails: stylelint reported 68 errors)
- `pnpm test:unit apps/web-ele` (fails: No test files found)


------
https://chatgpt.com/codex/tasks/task_e_689acde96e688330b7b61020b0da4747