### PR TITLE
feat(web-ele): handle array index paths for advanced port

### DIFF
--- a/apps/web-ele/src/components/business/DeviceEditor/PropertyPanel.vue
+++ b/apps/web-ele/src/components/business/DeviceEditor/PropertyPanel.vue
@@ -149,10 +149,11 @@ function collectKeys(obj: any, prefix = ''): string[] {
   const results: string[] = [];
   if (prefix) results.push(prefix);
   if (Array.isArray(obj)) {
-    // 若数组元素为对象，递归其首个元素以暴露子路径
-    if (obj.length && typeof obj[0] === 'object') {
-      results.push(...collectKeys(obj[0], prefix));
-    }
+    // 遍历数组每一项，携带索引递归收集路径
+    obj.forEach((item, idx) => {
+      const p = prefix ? `${prefix}[${idx}]` : `[${idx}]`;
+      results.push(...collectKeys(item, p));
+    });
   } else if (obj && typeof obj === 'object') {
     for (const [k, v] of Object.entries(obj)) {
       const p = prefix ? `${prefix}.${k}` : k;
@@ -164,7 +165,9 @@ function collectKeys(obj: any, prefix = ''): string[] {
 
 function getValueByPath(obj: any, path: string) {
   return path
+    .replace(/\[(\w+)\]/g, '.$1')
     .split('.')
+    .filter(Boolean)
     .reduce((o: any, k: string) => (o && typeof o === 'object' ? o[k] : undefined), obj);
 }
 

--- a/apps/web-ele/src/components/business/ports/PortAdvRenderer.vue
+++ b/apps/web-ele/src/components/business/ports/PortAdvRenderer.vue
@@ -9,7 +9,9 @@ const store = useDeviceStore();
 
 function getByPath(obj: any, path: string) {
   return path
+    .replace(/\[(\w+)\]/g, '.$1')
     .split('.')
+    .filter(Boolean)
     .reduce((o: any, k: string) => (o && typeof o === 'object' ? o[k] : undefined), obj);
 }
 


### PR DESCRIPTION
## Summary
- support array index paths when collecting keys
- parse bracket notation in advanced port renderer

## Testing
- `pnpm test:unit`
- `pnpm lint` *(fails: 68 stylelint errors across various files)*

------
https://chatgpt.com/codex/tasks/task_e_689ad4b7b66c83309f14c0c4e7dd659e