### PR TITLE
feat: add mobile OSS upload and warning API

### DIFF
--- a/apps/web-antd/package.json
+++ b/apps/web-antd/package.json
@@ -42,9 +42,13 @@
     "@vben/utils": "workspace:*",
     "@vueuse/core": "catalog:",
     "ant-design-vue": "catalog:",
+    "crypto-js": "^4.2.0",
     "dayjs": "catalog:",
     "pinia": "catalog:",
     "vue": "catalog:",
     "vue-router": "catalog:"
+  },
+  "devDependencies": {
+    "@types/crypto-js": "^4.2.2"
   }
 }

--- a/apps/web-antd/src/api/index.ts
+++ b/apps/web-antd/src/api/index.ts
@@ -1,1 +1,3 @@
 export * from './core';
+export * from './oss';
+export * from './warning';

--- a/apps/web-antd/src/api/oss.ts
+++ b/apps/web-antd/src/api/oss.ts
@@ -1,0 +1,44 @@
+import CryptoJS from 'crypto-js';
+
+export interface UploadOptions {
+  bucket: string;
+  namespace: string;
+  path: string;
+  file: File;
+  apiKey: string;
+}
+
+function makeSignature(bucket: string, timestamp: string, path: string, apiKey: string) {
+  const innerStr = `${bucket}@@${timestamp}@@${path}`;
+  const innerHash = CryptoJS.SHA256(CryptoJS.enc.Utf8.parse(innerStr)).toString(
+    CryptoJS.enc.Hex,
+  );
+  const outerStr = innerHash + apiKey;
+  return CryptoJS.SHA256(CryptoJS.enc.Utf8.parse(outerStr)).toString(CryptoJS.enc.Hex);
+}
+
+export async function uploadOssFile({ bucket, namespace, path, file, apiKey }: UploadOptions) {
+  const timestamp = Math.floor(Date.now() / 1000).toString();
+  const signature = makeSignature(bucket, timestamp, path, apiKey);
+
+  const formData = new FormData();
+  formData.append('namespace', namespace);
+  formData.append('timestamp', timestamp);
+  formData.append('signature', signature);
+  formData.append('path', path);
+  formData.append('file', file);
+
+  const uploadURL = `https://pingan1.lzjtu.edu.cn/api/oss/v1/file/upload/${bucket}`;
+
+  const response = await fetch(uploadURL, {
+    method: 'POST',
+    body: formData,
+  });
+
+  if (!response.ok) {
+    throw new Error(`Upload failed: ${response.status}`);
+  }
+
+  return response.json();
+}
+

--- a/apps/web-antd/src/api/warning.ts
+++ b/apps/web-antd/src/api/warning.ts
@@ -1,0 +1,14 @@
+import { requestClient } from '#/api/request';
+
+export interface WarningEliminateParams {
+  warning_log_id: string;
+  reason: string;
+  description: string;
+  type: string;
+  attachments: string[];
+}
+
+export function warningEliminate(data: WarningEliminateParams) {
+  return requestClient.post('/api/v1/paxy/warning/warningEliminate', data);
+}
+

--- a/apps/web-antd/src/views/h5/mobile/warning/detail.vue
+++ b/apps/web-antd/src/views/h5/mobile/warning/detail.vue
@@ -1,0 +1,76 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { useRoute } from 'vue-router';
+import { Page } from '@vben/common-ui';
+import { Form, Input, Upload, Button, message } from 'ant-design-vue';
+import type { UploadRequestOption as RcCustomRequestOptions } from 'ant-design-vue/es/vc-upload/interface';
+
+import { uploadOssFile } from '#/api/oss';
+import { warningEliminate } from '#/api/warning';
+
+const route = useRoute();
+
+const form = ref({
+  warning_log_id: (route.query.id as string) || '',
+  reason: '',
+  description: '',
+  type: '在校',
+  attachments: [] as string[],
+});
+
+const fileList = ref<any[]>([]);
+
+const customRequest = async (options: RcCustomRequestOptions) => {
+  const { file, onError, onSuccess } = options;
+  try {
+    const resp = await uploadOssFile({
+      bucket: 'test',
+      namespace: 'test',
+      path: '/mobile/',
+      file: file as File,
+      apiKey: import.meta.env.VITE_OSS_API_KEY || '',
+    });
+    const url = resp.url || resp.data?.url;
+    if (url) {
+      form.value.attachments.push(url);
+    }
+    onSuccess?.(resp as any);
+  } catch (err) {
+    onError?.(err as Error);
+  }
+};
+
+const submit = async () => {
+  try {
+    await warningEliminate(form.value);
+    message.success('提交成功');
+  } catch (err) {
+    message.error('提交失败');
+  }
+};
+</script>
+
+<template>
+  <Page title="预警详情">
+    <Form :model="form" layout="vertical">
+      <Form.Item label="理由">
+        <Input v-model:value="form.reason" />
+      </Form.Item>
+      <Form.Item label="描述">
+        <Input.TextArea v-model:value="form.description" />
+      </Form.Item>
+      <Form.Item label="附件">
+        <Upload
+          v-model:file-list="fileList"
+          :custom-request="customRequest"
+          list-type="picture-card"
+        >
+          <Button type="dashed">上传</Button>
+        </Upload>
+      </Form.Item>
+      <Form.Item>
+        <Button type="primary" @click="submit">提交</Button>
+      </Form.Item>
+    </Form>
+  </Page>
+</template>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -701,6 +701,9 @@ importers:
       ant-design-vue:
         specifier: 'catalog:'
         version: 4.2.6(vue@3.5.13(typescript@5.8.3))
+      crypto-js:
+        specifier: ^4.2.0
+        version: 4.2.0
       dayjs:
         specifier: 'catalog:'
         version: 1.11.13
@@ -713,6 +716,10 @@ importers:
       vue-router:
         specifier: 'catalog:'
         version: 4.5.1(vue@3.5.13(typescript@5.8.3))
+    devDependencies:
+      '@types/crypto-js':
+        specifier: ^4.2.2
+        version: 4.2.2
 
   apps/web-ele:
     dependencies:
@@ -4374,6 +4381,9 @@ packages:
 
   '@types/conventional-commits-parser@5.0.1':
     resolution: {integrity: sha512-7uz5EHdzz2TqoMfV7ee61Egf5y6NkcO4FB/1iCCQnbeiI1F3xzv3vK5dBCXUCLQgGYS+mUeigK1iKQzvED+QnQ==}
+
+  '@types/crypto-js@4.2.2':
+    resolution: {integrity: sha512-sDOLlVbHhXpAUAL0YHDUUwDZf3iN4Bwi4W6a0W0b+QcAezUbRtH4FVb+9J4h+XFPW7l/gQ9F8qC7P+Ec4k8QVQ==}
 
   '@types/eslint@9.6.1':
     resolution: {integrity: sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==}
@@ -14193,6 +14203,8 @@ snapshots:
   '@types/conventional-commits-parser@5.0.1':
     dependencies:
       '@types/node': 22.15.3
+
+  '@types/crypto-js@4.2.2': {}
 
   '@types/eslint@9.6.1':
     dependencies:


### PR DESCRIPTION
## Summary
- add CryptoJS dependency for mobile OSS uploads
- implement `uploadOssFile` helper and warning elimination API
- add mobile warning detail view with file upload support

## Testing
- `pnpm --filter @vben/web-antd run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689ca1f506b88330ada146ece4363d49