### PR TITLE
feat: enable cross-canvas port linking

### DIFF
--- a/apps/web-ele/src/views/control/network-topology/components/CanvasRightPanel.vue
+++ b/apps/web-ele/src/views/control/network-topology/components/CanvasRightPanel.vue
@@ -55,7 +55,7 @@
             (设备:{{ cfg.devices.length }} 连线:{{ cfg.edges.length }})
           </span>
         </span>
-        <button @click.stop="restoreConfigToCanvas(cfg)" style="margin-right: 5px">
+        <button @click.stop="restoreConfigToCanvas(name, cfg)" style="margin-right: 5px">
           恢复
         </button>
         <button @click.stop="exportOneConfig(name)" style="margin-right: 5px">
@@ -97,7 +97,8 @@ const emits = defineEmits([
   'importConfigs',
 ]);
 const exportAllConfigs = () => emits('exportAllConfigs');
-const restoreConfigToCanvas = (cfg: any) => emits('restoreConfigToCanvas', cfg);
+const restoreConfigToCanvas = (name: string, cfg: any) =>
+  emits('restoreConfigToCanvas', name, cfg);
 const exportOneConfig = (name: string) => emits('exportOneConfig', name);
 const removeConfig = (name: string) => emits('removeConfig', name);
 const connectToExternalRoom = (name: string) => emits('connectToExternalRoom', name);

--- a/apps/web-ele/src/views/control/network-topology/components/ExternalLines.vue
+++ b/apps/web-ele/src/views/control/network-topology/components/ExternalLines.vue
@@ -1,24 +1,18 @@
 <template>
-  <defs>
-    <linearGradient id="orangeWhiteDash" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#FFA500"/>
-      <stop offset="50%" stop-color="#fff"/>
-      <stop offset="100%" stop-color="#FFA500"/>
-    </linearGradient>
-  </defs>
   <template v-for="(edge, idx) in edges" :key="idx">
     <g v-if="getEdgePositions(edge)">
       <path
         :d="bezierPath(getEdgePositions(edge).source, getEdgePositions(edge).target)"
-        stroke="#ffa50055"
+        :stroke="(edge.color || '#FFA500') + '55'"
         stroke-width="2"
         fill="none"
         stroke-linecap="round"
         marker-end="url(#arrowhead)"
+        :style="{ color: edge.color || '#FFA500' }"
       />
       <path
         :d="bezierPath(getEdgePositions(edge).source, getEdgePositions(edge).target)"
-        stroke="url(#orangeWhiteDash)"
+        :stroke="edge.color || '#FFA500'"
         stroke-width="4"
         fill="none"
         stroke-linecap="round"
@@ -37,7 +31,7 @@
         :x="getEdgePositions(edge).externalPoint.x + 7"
         :y="getEdgePositions(edge).externalPoint.y + 12"
         font-size="14"
-        fill="#FFA500"
+        :fill="edge.color || '#FFA500'"
         style="pointer-events: none; font-weight: bold"
       >
         {{ getEdgePositions(edge).externalName }}

--- a/apps/web-ele/src/views/control/network-topology/components/ExternalLines.vue
+++ b/apps/web-ele/src/views/control/network-topology/components/ExternalLines.vue
@@ -34,8 +34,8 @@
         />
       </path>
       <text
-        :x="getEdgePositions(edge).target.x + 7"
-        :y="getEdgePositions(edge).target.y + 12"
+        :x="getEdgePositions(edge).externalPoint.x + 7"
+        :y="getEdgePositions(edge).externalPoint.y + 12"
         font-size="14"
         fill="#FFA500"
         style="pointer-events: none; font-weight: bold"

--- a/apps/web-ele/src/views/control/network-topology/components/InternalLines.vue
+++ b/apps/web-ele/src/views/control/network-topology/components/InternalLines.vue
@@ -1,24 +1,18 @@
 <template>
-  <defs>
-    <linearGradient id="blueWhiteDash" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#01E6FF" />
-      <stop offset="50%" stop-color="white" />
-      <stop offset="100%" stop-color="#01E6FF" />
-    </linearGradient>
-  </defs>
   <template v-for="(edge, idx) in edges" :key="idx">
     <g v-if="getEdgePositions(edge)">
       <path
         :d="bezierPath(getEdgePositions(edge).source, getEdgePositions(edge).target)"
-        stroke="#19baff66"
+        :stroke="(edge.color || '#01E6FF') + '55'"
         stroke-width="2"
         fill="none"
         stroke-linecap="round"
         marker-end="url(#arrowhead)"
+        :style="{ color: edge.color || '#01E6FF' }"
       />
       <path
         :d="bezierPath(getEdgePositions(edge).source, getEdgePositions(edge).target)"
-        stroke="url(#blueWhiteDash)"
+        :stroke="edge.color || '#01E6FF'"
         stroke-width="4"
         fill="none"
         stroke-linecap="round"

--- a/apps/web-ele/src/views/control/network-topology/components/TopoToolbar.vue
+++ b/apps/web-ele/src/views/control/network-topology/components/TopoToolbar.vue
@@ -80,6 +80,24 @@
     >
       外部连接
     </button>
+
+    <!-- 连线颜色选择 -->
+    <input
+      type="color"
+      :value="lineColor"
+      @input="emit('update:line-color', ($event.target as HTMLInputElement).value)"
+    />
+
+    <!-- 连线开关 -->
+    <button
+      :style="{
+        background: linkEnabled ? '#0f0' : '#222',
+        color: linkEnabled ? '#222' : '#fff',
+      }"
+      @click="emit('toggle-link-enabled')"
+    >
+      {{ linkEnabled ? '禁用连线' : '启用连线' }}
+    </button>
   </div>
 </template>
 
@@ -93,6 +111,8 @@ const props = defineProps<{
   connectMode: string;
   canvasWidth: number;
   canvasHeight: number;
+  lineColor: string;
+  linkEnabled: boolean;
 }>();
 const { canvasWidth, canvasHeight } = toRefs(props);
 
@@ -106,6 +126,8 @@ const emit = defineEmits([
   'update:canvas-width',
   'update:canvas-height',
   'remove-selected-device',
+  'update:line-color',
+  'toggle-link-enabled',
 ]);
 
 /* ---------- methods ---------- */

--- a/apps/web-ele/src/views/control/network-topology/index.vue
+++ b/apps/web-ele/src/views/control/network-topology/index.vue
@@ -696,13 +696,24 @@ function getEdgePositions(edge: any) {
     return { x, y };
   };
 
+  const current = currentCanvasName.value;
   let source = null;
   let target = null;
-  if (edge.source.devUUid && edge.source.portId) {
-    source = portPos(edge.source.devUUid, edge.source.portId);
+  if (
+    edge.source.canvas === undefined ||
+    edge.source.canvas === current
+  ) {
+    if (edge.source.devUUid && edge.source.portId) {
+      source = portPos(edge.source.devUUid, edge.source.portId);
+    }
   }
-  if ((edge.target as any).devUUid && (edge.target as any).portId) {
-    target = portPos((edge.target as any).devUUid, (edge.target as any).portId);
+  if (
+    (edge.target as any).canvas === undefined ||
+    (edge.target as any).canvas === current
+  ) {
+    if ((edge.target as any).devUUid && (edge.target as any).portId) {
+      target = portPos((edge.target as any).devUUid, (edge.target as any).portId);
+    }
   }
 
   const roomList = Object.keys(topoConfigs.value);
@@ -716,7 +727,10 @@ function getEdgePositions(edge: any) {
   if (!source) {
     const name = edge.source.canvas || edge.source.externalRoom || '';
     const idx = roomList.indexOf(name);
-    source = { x: canvasWidth - 30, y: 120 + idx * gapY };
+    source = {
+      x: canvasWidth - 30,
+      y: 120 + (idx >= 0 ? idx : roomList.length) * gapY,
+    };
     externalName = name;
     externalPoint = source;
   }
@@ -726,7 +740,10 @@ function getEdgePositions(edge: any) {
       (edge.target as any).externalRoom ||
       '';
     const idx = roomList.indexOf(name);
-    target = { x: canvasWidth - 30, y: 120 + idx * gapY };
+    target = {
+      x: canvasWidth - 30,
+      y: 120 + (idx >= 0 ? idx : roomList.length) * gapY,
+    };
     externalName = name;
     externalPoint = target;
   }
@@ -822,16 +839,21 @@ function onPortClick(devUUid: string, portId: string) {
           portId,
         },
       };
+      // 在源画布记录原向连线
       source.edges.push(deepClone(edge));
       // 在当前(目标)画布记录反向连线
       edges.value.push({
         external: true,
         source: {
+          canvas: currentCanvasName.value || '',
+          devUUid,
+          portId,
+        },
+        target: {
           canvas: source.name || '',
           devUUid: source.sourcePort.devUUid,
           portId: source.sourcePort.portId,
         },
-        target: { devUUid, portId },
       });
       if (currentCanvasName.value && topoConfigs.value[currentCanvasName.value]) {
         topoConfigs.value[currentCanvasName.value].edges = deepClone(edges.value);

--- a/apps/web-ele/src/views/control/network-topology/index.vue
+++ b/apps/web-ele/src/views/control/network-topology/index.vue
@@ -712,11 +712,13 @@ function getEdgePositions(edge: any) {
   const gapY = Math.max(60, (canvasHeight - 240) / Math.max(1, roomList.length));
 
   let externalName = '';
+  let externalPoint = null;
   if (!source) {
     const name = edge.source.canvas || edge.source.externalRoom || '';
     const idx = roomList.indexOf(name);
-    source = { x: 30, y: 120 + idx * gapY };
+    source = { x: canvasWidth - 30, y: 120 + idx * gapY };
     externalName = name;
+    externalPoint = source;
   }
   if (!target) {
     const name =
@@ -726,6 +728,7 @@ function getEdgePositions(edge: any) {
     const idx = roomList.indexOf(name);
     target = { x: canvasWidth - 30, y: 120 + idx * gapY };
     externalName = name;
+    externalPoint = target;
   }
 
   if (!source || !target) return null;
@@ -734,6 +737,7 @@ function getEdgePositions(edge: any) {
     target,
     color: edge.external ? '#FFA500' : '#01E6FF',
     externalName,
+    externalPoint,
   };
 }
 


### PR DESCRIPTION
## Summary
- allow restoring canvases with name
- add cross-canvas port linking workflow
- compute positions for cross-canvas edges

## Testing
- `pnpm lint` *(fails: stylelint rule errors)*
- `pnpm test:unit`

------
https://chatgpt.com/codex/tasks/task_e_689d8b298a6c833090ca7cfb9f489c3b