### PR TITLE
fix: apply selected line color

### DIFF
--- a/apps/web-ele/src/views/control/network-topology/components/ExternalLines.vue
+++ b/apps/web-ele/src/views/control/network-topology/components/ExternalLines.vue
@@ -3,16 +3,16 @@
     <g v-if="getEdgePositions(edge)">
       <path
         :d="bezierPath(getEdgePositions(edge).source, getEdgePositions(edge).target)"
-        :stroke="(edge.color || '#FFA500') + '55'"
+        :stroke="getEdgePositions(edge).color + '55'"
         stroke-width="2"
         fill="none"
         stroke-linecap="round"
         marker-end="url(#arrowhead)"
-        :style="{ color: edge.color || '#FFA500' }"
+        :style="{ color: getEdgePositions(edge).color }"
       />
       <path
         :d="bezierPath(getEdgePositions(edge).source, getEdgePositions(edge).target)"
-        :stroke="edge.color || '#FFA500'"
+        :stroke="getEdgePositions(edge).color"
         stroke-width="4"
         fill="none"
         stroke-linecap="round"
@@ -31,7 +31,7 @@
         :x="getEdgePositions(edge).externalPoint.x + 7"
         :y="getEdgePositions(edge).externalPoint.y + 12"
         font-size="14"
-        :fill="edge.color || '#FFA500'"
+        :fill="getEdgePositions(edge).color"
         style="pointer-events: none; font-weight: bold"
       >
         {{ getEdgePositions(edge).externalName }}

--- a/apps/web-ele/src/views/control/network-topology/components/InternalLines.vue
+++ b/apps/web-ele/src/views/control/network-topology/components/InternalLines.vue
@@ -3,16 +3,16 @@
     <g v-if="getEdgePositions(edge)">
       <path
         :d="bezierPath(getEdgePositions(edge).source, getEdgePositions(edge).target)"
-        :stroke="(edge.color || '#01E6FF') + '55'"
+        :stroke="getEdgePositions(edge).color + '55'"
         stroke-width="2"
         fill="none"
         stroke-linecap="round"
         marker-end="url(#arrowhead)"
-        :style="{ color: edge.color || '#01E6FF' }"
+        :style="{ color: getEdgePositions(edge).color }"
       />
       <path
         :d="bezierPath(getEdgePositions(edge).source, getEdgePositions(edge).target)"
-        :stroke="edge.color || '#01E6FF'"
+        :stroke="getEdgePositions(edge).color"
         stroke-width="4"
         fill="none"
         stroke-linecap="round"

--- a/apps/web-ele/src/views/control/network-topology/components/TopoToolbar.vue
+++ b/apps/web-ele/src/views/control/network-topology/components/TopoToolbar.vue
@@ -85,7 +85,8 @@
     <input
       type="color"
       :value="lineColor"
-      @input="emit('update:line-color', ($event.target as HTMLInputElement).value)"
+      @input="updateLineColor"
+      @change="updateLineColor"
     />
 
     <!-- 连线开关 -->
@@ -114,7 +115,7 @@ const props = defineProps<{
   lineColor: string;
   linkEnabled: boolean;
 }>();
-const { canvasWidth, canvasHeight } = toRefs(props);
+const { canvasWidth, canvasHeight, lineColor } = toRefs(props);
 
 const emit = defineEmits([
   'update:selected-device-id',
@@ -134,6 +135,10 @@ const emit = defineEmits([
 function onSelectDevice(e: Event) {
   const val = (e.target as HTMLSelectElement).value;
   emit('update:selected-device-id', val);
+}
+
+function updateLineColor(e: Event) {
+  emit('update:line-color', (e.target as HTMLInputElement).value);
 }
 </script>
 

--- a/apps/web-ele/src/views/control/network-topology/index.vue
+++ b/apps/web-ele/src/views/control/network-topology/index.vue
@@ -755,7 +755,10 @@ function getEdgePositions(edge: any) {
   return {
     source,
     target,
-    color: edge.external ? '#FFA500' : '#01E6FF',
+    // Use the edge's own color when provided; otherwise fall back to the
+    // currently selected line color for internal connections, keeping the
+    // default orange for external lines.
+    color: edge.color || (edge.external ? '#FFA500' : lineColor.value),
     externalName,
     externalPoint,
   };
@@ -955,7 +958,7 @@ function onKeyDown(e: KeyboardEvent) {
         :connect-mode="connectMode"
         :canvas-width="canvasWidth"
         :canvas-height="canvasHeight"
-        :line-color="lineColor"
+        :line-color="lineColor.value"
         :link-enabled="linkEnabled"
         @update:selected-device-id="(val) => (selectedDeviceId = val)"
         @update:new-config-name="(val) => (newConfigName = val)"


### PR DESCRIPTION
## Summary
- propagate selected line color to edge fallback logic
- render internal and external lines solely with computed edge colors

## Testing
- `pnpm lint apps/web-ele` *(fails: stylelint rule violations)*
- `pnpm test:unit apps/web-ele` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_689e91196ac08330a72219dc9408a820