### PR TITLE
fix: apply selected line color

### DIFF
--- a/apps/web-ele/src/views/control/network-topology/components/ExternalLines.vue
+++ b/apps/web-ele/src/views/control/network-topology/components/ExternalLines.vue
@@ -3,16 +3,16 @@
     <g v-if="getEdgePositions(edge)">
       <path
         :d="bezierPath(getEdgePositions(edge).source, getEdgePositions(edge).target)"
-        :stroke="(edge.color || '#FFA500') + '55'"
+        :stroke="(getEdgePositions(edge).color || '#FFA500') + '55'"
         stroke-width="2"
         fill="none"
         stroke-linecap="round"
         marker-end="url(#arrowhead)"
-        :style="{ color: edge.color || '#FFA500' }"
+        :style="{ color: getEdgePositions(edge).color || '#FFA500' }"
       />
       <path
         :d="bezierPath(getEdgePositions(edge).source, getEdgePositions(edge).target)"
-        :stroke="edge.color || '#FFA500'"
+        :stroke="getEdgePositions(edge).color || '#FFA500'"
         stroke-width="4"
         fill="none"
         stroke-linecap="round"
@@ -31,7 +31,7 @@
         :x="getEdgePositions(edge).externalPoint.x + 7"
         :y="getEdgePositions(edge).externalPoint.y + 12"
         font-size="14"
-        :fill="edge.color || '#FFA500'"
+        :fill="getEdgePositions(edge).color || '#FFA500'"
         style="pointer-events: none; font-weight: bold"
       >
         {{ getEdgePositions(edge).externalName }}

--- a/apps/web-ele/src/views/control/network-topology/components/InternalLines.vue
+++ b/apps/web-ele/src/views/control/network-topology/components/InternalLines.vue
@@ -3,16 +3,16 @@
     <g v-if="getEdgePositions(edge)">
       <path
         :d="bezierPath(getEdgePositions(edge).source, getEdgePositions(edge).target)"
-        :stroke="(edge.color || '#01E6FF') + '55'"
+        :stroke="(getEdgePositions(edge).color || '#01E6FF') + '55'"
         stroke-width="2"
         fill="none"
         stroke-linecap="round"
         marker-end="url(#arrowhead)"
-        :style="{ color: edge.color || '#01E6FF' }"
+        :style="{ color: getEdgePositions(edge).color || '#01E6FF' }"
       />
       <path
         :d="bezierPath(getEdgePositions(edge).source, getEdgePositions(edge).target)"
-        :stroke="edge.color || '#01E6FF'"
+        :stroke="getEdgePositions(edge).color || '#01E6FF'"
         stroke-width="4"
         fill="none"
         stroke-linecap="round"

--- a/apps/web-ele/src/views/control/network-topology/components/TopoToolbar.vue
+++ b/apps/web-ele/src/views/control/network-topology/components/TopoToolbar.vue
@@ -85,7 +85,8 @@
     <input
       type="color"
       :value="lineColor"
-      @input="emit('update:line-color', ($event.target as HTMLInputElement).value)"
+      @input="updateLineColor"
+      @change="updateLineColor"
     />
 
     <!-- 连线开关 -->
@@ -114,7 +115,7 @@ const props = defineProps<{
   lineColor: string;
   linkEnabled: boolean;
 }>();
-const { canvasWidth, canvasHeight } = toRefs(props);
+const { canvasWidth, canvasHeight, lineColor } = toRefs(props);
 
 const emit = defineEmits([
   'update:selected-device-id',
@@ -134,6 +135,10 @@ const emit = defineEmits([
 function onSelectDevice(e: Event) {
   const val = (e.target as HTMLSelectElement).value;
   emit('update:selected-device-id', val);
+}
+
+function updateLineColor(e: Event) {
+  emit('update:line-color', (e.target as HTMLInputElement).value);
 }
 </script>
 

--- a/apps/web-ele/src/views/control/network-topology/index.vue
+++ b/apps/web-ele/src/views/control/network-topology/index.vue
@@ -118,11 +118,15 @@ const edges = ref<
       | { externalRoom: string };
   }[]
 >([]);
-const drawingLine = ref<null | {
-  devUUid: string;
-  from: { x: number; y: number };
-  portId: string;
-}>(null);
+const drawingLine = ref<
+  | null
+  | {
+      devUUid: string;
+      from: { x: number; y: number };
+      portId: string;
+      color: string;
+    }
+>(null);
 const mousePos = ref<null | { x: number; y: number }>(null);
 const selectedPort = ref<null | { devUUid: string; portId: string }>(null);
 const dragging = ref(false);
@@ -755,7 +759,7 @@ function getEdgePositions(edge: any) {
   return {
     source,
     target,
-    color: edge.external ? '#FFA500' : '#01E6FF',
+    color: edge.color || (edge.external ? '#FFA500' : lineColor.value),
     externalName,
     externalPoint,
   };
@@ -806,7 +810,7 @@ function onPortClick(devUUid: string, portId: string) {
         drawingLine.value.portId !== portId
       ) {
         edges.value.push({
-          color: lineColor.value,
+          color: drawingLine.value.color,
           source: {
             devUUid: drawingLine.value.devUUid,
             portId: drawingLine.value.portId,
@@ -818,7 +822,7 @@ function onPortClick(devUUid: string, portId: string) {
       selectedPort.value = null;
       mousePos.value = null;
     } else {
-      drawingLine.value = { devUUid, portId, from: pos };
+      drawingLine.value = { devUUid, portId, from: pos, color: lineColor.value };
       selectedPort.value = { devUUid, portId };
     }
   } else if (connectMode.value === 'external') {
@@ -843,7 +847,7 @@ function onPortClick(devUUid: string, portId: string) {
       const source = sourceCanvasBackup.value;
       const edge = {
         external: true,
-        color: lineColor.value,
+        color: drawingLine.value?.color || lineColor.value,
         source: {
           canvas: source.name || '',
           devUUid: source.sourcePort.devUUid,
@@ -860,7 +864,7 @@ function onPortClick(devUUid: string, portId: string) {
       // 在当前(目标)画布记录反向连线
       edges.value.push({
         external: true,
-        color: lineColor.value,
+        color: drawingLine.value?.color || lineColor.value,
         source: {
           canvas: currentCanvasName.value || '',
           devUUid,
@@ -888,7 +892,7 @@ function onPortClick(devUUid: string, portId: string) {
       selectedPort.value = null;
       mousePos.value = null;
     } else {
-      drawingLine.value = { devUUid, portId, from: pos };
+      drawingLine.value = { devUUid, portId, from: pos, color: lineColor.value };
       selectedPort.value = { devUUid, portId };
     }
   }


### PR DESCRIPTION
## Summary
- persist chosen color when starting a connection and reuse it when creating edges
- default edge rendering to current toolbar color when none stored

## Testing
- `pnpm lint apps/web-ele` *(warn: formatting/style warnings)*
- `pnpm test:unit apps/web-ele` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_689e91196ac08330a72219dc9408a820