### PR TITLE
feat: allow customizing network topology line color

### DIFF
--- a/apps/web-ele/src/router/routes/modules/industrialControl.ts
+++ b/apps/web-ele/src/router/routes/modules/industrialControl.ts
@@ -48,14 +48,10 @@ const controlRoutes: RouteRecordRaw[] = [
     component: () => import('#/views/control/test/index.vue'),
     meta: { icon: 'lucide:monitor', title: '机柜', order: 5 },
   },
-  // apps/web-ele/src/views/control/networkTopologyDiagram/components/TopologyGraph.vue
   {
     name: 'TopologyGraph',
     path: '/control/topology-graph',
-    component: () =>
-      import(
-        '#/views/control/networkTopologyDiagram/components/TopologyGraph.vue'
-      ),
+    component: () => import('#/views/control/networkTopologyDiagram/index.vue'),
   },
 ];
 

--- a/apps/web-ele/src/views/control/networkTopologyDiagram/components/TopologyGraph.vue
+++ b/apps/web-ele/src/views/control/networkTopologyDiagram/components/TopologyGraph.vue
@@ -150,17 +150,6 @@ function draw() {
   ctx.save();
   ctx.scale(DPR, DPR);
 
-  // DEBUG: draw a red line and green box
-  ctx.beginPath();
-  ctx.moveTo(0, 0);
-  ctx.lineTo(300, 300);
-  ctx.strokeStyle = 'red';
-  ctx.lineWidth = 3;
-  ctx.stroke();
-
-  ctx.fillStyle = 'green';
-  ctx.fillRect(10, 10, 100, 50);
-
   /* Bezier Links */
   ctx.strokeStyle = lineColor.value; // 亮色连线，黑底可见
   ctx.lineWidth = 2;
@@ -216,6 +205,7 @@ onMounted(async () => {
   draw();
 });
 watch(() => props.topologyData, draw, { deep: true });
+watch(lineColor, draw);
 </script>
 
 <template>

--- a/apps/web-ele/src/views/control/networkTopologyDiagram/index.vue
+++ b/apps/web-ele/src/views/control/networkTopologyDiagram/index.vue
@@ -3,12 +3,19 @@ import { ref } from 'vue';
 
 import TopologyGraph from './components/TopologyGraph.vue';
 
+const pickerColor = ref('#4cafef');
 const lineColor = ref('#4cafef');
+function applyColor() {
+  lineColor.value = pickerColor.value;
+}
 </script>
 
 <template>
   <div class="p-4">
-    <input type="color" v-model="lineColor" class="mb-4" />
+    <input type="color" v-model="pickerColor" class="mb-2" />
+    <button class="ml-2 rounded border px-2 py-1" @click="applyColor">
+      确认
+    </button>
     <TopologyGraph :topology-data="{}" :line-color="lineColor" />
   </div>
 </template>

--- a/apps/web-ele/src/views/control/networkTopologyDiagram/index.vue
+++ b/apps/web-ele/src/views/control/networkTopologyDiagram/index.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+
+import TopologyGraph from './components/TopologyGraph.vue';
+
+const lineColor = ref('#4cafef');
+</script>
+
+<template>
+  <div class="p-4">
+    <input type="color" v-model="lineColor" class="mb-4" />
+    <TopologyGraph :topology-data="{}" :line-color="lineColor" />
+  </div>
+</template>


### PR DESCRIPTION
## Summary
- allow TopologyGraph line color customization via prop
- add color picker page for network topology
- route topology graph to new demo page

## Testing
- `pnpm exec eslint apps/web-ele/src/views/control/networkTopologyDiagram/components/TopologyGraph.vue apps/web-ele/src/views/control/networkTopologyDiagram/index.vue apps/web-ele/src/router/routes/modules/industrialControl.ts`
- `pnpm exec stylelint apps/web-ele/src/views/control/networkTopologyDiagram/components/TopologyGraph.vue apps/web-ele/src/views/control/networkTopologyDiagram/index.vue`
- `pnpm -F @vben/web-ele typecheck` *(fails: Cannot find module 'axios' and other type errors)*

------
https://chatgpt.com/codex/tasks/task_e_689ed2554ce08330b28d13c9b22b4d7f