### PR TITLE
feat: add line color selector for topology connections

### DIFF
--- a/apps/web-ele/src/views/control/network-topology/components/ExternalLines.vue
+++ b/apps/web-ele/src/views/control/network-topology/components/ExternalLines.vue
@@ -1,24 +1,37 @@
 <template>
   <defs>
-    <linearGradient id="orangeWhiteDash" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#FFA500"/>
-      <stop offset="50%" stop-color="#fff"/>
-      <stop offset="100%" stop-color="#FFA500"/>
-    </linearGradient>
+    <template v-for="(edge, idx) in edges" :key="idx">
+      <linearGradient :id="`ext-dash-${idx}`" x1="0%" y1="0%" x2="100%" y2="0%">
+        <stop offset="0%" :stop-color="getEdgePositions(edge).color"/>
+        <stop offset="50%" stop-color="#fff"/>
+        <stop offset="100%" :stop-color="getEdgePositions(edge).color"/>
+      </linearGradient>
+      <marker
+        :id="`ext-arrow-${idx}`"
+        markerWidth="8"
+        markerHeight="8"
+        refX="8"
+        refY="4"
+        orient="auto"
+        markerUnits="strokeWidth"
+      >
+        <path d="M0,0 L8,4 L0,8" :fill="getEdgePositions(edge).color" />
+      </marker>
+    </template>
   </defs>
   <template v-for="(edge, idx) in edges" :key="idx">
     <g v-if="getEdgePositions(edge)">
       <path
         :d="bezierPath(getEdgePositions(edge).source, getEdgePositions(edge).target)"
-        stroke="#ffa50055"
+        :stroke="getEdgePositions(edge).color + '55'"
         stroke-width="2"
         fill="none"
         stroke-linecap="round"
-        marker-end="url(#arrowhead)"
+        :marker-end="`url(#ext-arrow-${idx})`"
       />
       <path
         :d="bezierPath(getEdgePositions(edge).source, getEdgePositions(edge).target)"
-        stroke="url(#orangeWhiteDash)"
+        :stroke="`url(#ext-dash-${idx})`"
         stroke-width="4"
         fill="none"
         stroke-linecap="round"
@@ -37,7 +50,7 @@
         :x="getEdgePositions(edge).externalPoint.x + 7"
         :y="getEdgePositions(edge).externalPoint.y + 12"
         font-size="14"
-        fill="#FFA500"
+        :fill="getEdgePositions(edge).color"
         style="pointer-events: none; font-weight: bold"
       >
         {{ getEdgePositions(edge).externalName }}

--- a/apps/web-ele/src/views/control/network-topology/components/InternalLines.vue
+++ b/apps/web-ele/src/views/control/network-topology/components/InternalLines.vue
@@ -1,24 +1,37 @@
 <template>
   <defs>
-    <linearGradient id="blueWhiteDash" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#01E6FF" />
-      <stop offset="50%" stop-color="white" />
-      <stop offset="100%" stop-color="#01E6FF" />
-    </linearGradient>
+    <template v-for="(edge, idx) in edges" :key="idx">
+      <linearGradient :id="`dash-${idx}`" x1="0%" y1="0%" x2="100%" y2="0%">
+        <stop offset="0%" :stop-color="getEdgePositions(edge).color" />
+        <stop offset="50%" stop-color="white" />
+        <stop offset="100%" :stop-color="getEdgePositions(edge).color" />
+      </linearGradient>
+      <marker
+        :id="`arrow-${idx}`"
+        markerWidth="8"
+        markerHeight="8"
+        refX="8"
+        refY="4"
+        orient="auto"
+        markerUnits="strokeWidth"
+      >
+        <path d="M0,0 L8,4 L0,8" :fill="getEdgePositions(edge).color" />
+      </marker>
+    </template>
   </defs>
   <template v-for="(edge, idx) in edges" :key="idx">
     <g v-if="getEdgePositions(edge)">
       <path
         :d="bezierPath(getEdgePositions(edge).source, getEdgePositions(edge).target)"
-        stroke="#19baff66"
+        :stroke="getEdgePositions(edge).color + '66'"
         stroke-width="2"
         fill="none"
         stroke-linecap="round"
-        marker-end="url(#arrowhead)"
+        :marker-end="`url(#arrow-${idx})`"
       />
       <path
         :d="bezierPath(getEdgePositions(edge).source, getEdgePositions(edge).target)"
-        stroke="url(#blueWhiteDash)"
+        :stroke="`url(#dash-${idx})`"
         stroke-width="4"
         fill="none"
         stroke-linecap="round"

--- a/apps/web-ele/src/views/control/network-topology/components/TopoToolbar.vue
+++ b/apps/web-ele/src/views/control/network-topology/components/TopoToolbar.vue
@@ -80,6 +80,13 @@
     >
       外部连接
     </button>
+
+    <label style="margin-left:8px">颜色:</label>
+    <input
+      type="color"
+      :value="lineColor"
+      @input="emit('update:line-color', ($event.target as HTMLInputElement).value)"
+    />
   </div>
 </template>
 
@@ -93,6 +100,7 @@ const props = defineProps<{
   connectMode: string;
   canvasWidth: number;
   canvasHeight: number;
+  lineColor: string;
 }>();
 const { canvasWidth, canvasHeight } = toRefs(props);
 
@@ -106,6 +114,7 @@ const emit = defineEmits([
   'update:canvas-width',
   'update:canvas-height',
   'remove-selected-device',
+  'update:line-color',
 ]);
 
 /* ---------- methods ---------- */

--- a/apps/web-ele/src/views/control/network-topology/index.vue
+++ b/apps/web-ele/src/views/control/network-topology/index.vue
@@ -111,6 +111,7 @@ const selectedDeviceId = ref<string>('');
 const edges = ref<
   {
     external?: boolean;
+    color?: string;
     source: { devUUid: string; portId: string; canvas?: string };
     target:
       | { devUUid: string; portId: string; canvas?: string }
@@ -186,6 +187,7 @@ const sourceCanvasBackup = ref<
 
 // 连线模式
 const connectMode = ref<'external' | 'internal'>('internal');
+const lineColor = ref('#01E6FF');
 const pendingExternalRoom = ref<null | string>(null);
 // 当前拖拽指针悬停的机柜 _uuid
 const hoveredCabinetId = ref<string | null>(null);
@@ -752,7 +754,7 @@ function getEdgePositions(edge: any) {
   return {
     source,
     target,
-    color: edge.external ? '#FFA500' : '#01E6FF',
+    color: edge.color || (edge.external ? '#FFA500' : '#01E6FF'),
     externalName,
     externalPoint,
   };
@@ -797,6 +799,7 @@ function onPortClick(devUUid: string, portId: string) {
             portId: drawingLine.value.portId,
           },
           target: { devUUid, portId },
+          color: lineColor.value,
         });
       }
       drawingLine.value = null;
@@ -828,6 +831,7 @@ function onPortClick(devUUid: string, portId: string) {
       const source = sourceCanvasBackup.value;
       const edge = {
         external: true,
+        color: lineColor.value,
         source: {
           canvas: source.name || '',
           devUUid: source.sourcePort.devUUid,
@@ -844,6 +848,7 @@ function onPortClick(devUUid: string, portId: string) {
       // 在当前(目标)画布记录反向连线
       edges.value.push({
         external: true,
+        color: lineColor.value,
         source: {
           canvas: currentCanvasName.value || '',
           devUUid,
@@ -936,6 +941,7 @@ function onKeyDown(e: KeyboardEvent) {
         :connect-mode="connectMode"
         :canvas-width="canvasWidth"
         :canvas-height="canvasHeight"
+        :line-color="lineColor"
         @update:selected-device-id="(val) => (selectedDeviceId = val)"
         @update:new-config-name="(val) => (newConfigName = val)"
         @add-device="addDevice"
@@ -944,6 +950,7 @@ function onKeyDown(e: KeyboardEvent) {
         @update:canvas-width="(val: number) => (canvasWidth = val)"
         @update:canvas-height="(val: number) => (canvasHeight = val)"
         @remove-selected-device="removeSelectedDevice"
+        @update:line-color="(val: string) => (lineColor.value = val)"
       />
       <!-- 设备实例渲染 -->
       <template v-for="dev in devicesOnCanvas" :key="dev._uuid">
@@ -1078,24 +1085,11 @@ function onKeyDown(e: KeyboardEvent) {
         <path
           v-if="drawingLine && drawingLine.from && mousePos"
           :d="bezierPath(drawingLine.from, mousePos)"
-          stroke="#01E6FF"
+          :stroke="lineColor"
           stroke-width="2"
           fill="none"
           stroke-dasharray="5,4"
         />
-        <defs>
-          <marker
-            id="arrowhead"
-            markerWidth="8"
-            markerHeight="8"
-            refX="8"
-            refY="4"
-            orient="auto"
-            markerUnits="strokeWidth"
-          >
-            <path d="M0,0 L8,4 L0,8" fill="#01E6FF" />
-          </marker>
-        </defs>
       </svg>
     </div>
     <!-- 右侧：全部画布列表（支持外部连线模式下点击） -->


### PR DESCRIPTION
## Summary
- allow selecting line colors for network topology connections
- render internal and external lines with chosen colors

## Testing
- `pnpm lint` *(fails: Expected empty line before rule, etc.)*
- `pnpm test:unit`


------
https://chatgpt.com/codex/tasks/task_e_689ee15b17f08330b7b79299b19495b1